### PR TITLE
add flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ _esy
 dune.mel
 .melange.eobjs
 dist/
+
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,149 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "melange": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "melange-compiler-libs": "melange-compiler-libs",
+        "nix-filter": "nix-filter",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1694502725,
+        "narHash": "sha256-2yjmvgKiA3p16mpCfpNlmB+jMT36Z94uQ+fU6G2koEA=",
+        "owner": "melange-re",
+        "repo": "melange",
+        "rev": "a01735398b5df5b90f0a567dd660847ae0e9da48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "melange-re",
+        "repo": "melange",
+        "rev": "a01735398b5df5b90f0a567dd660847ae0e9da48",
+        "type": "github"
+      }
+    },
+    "melange-compiler-libs": {
+      "inputs": {
+        "flake-utils": [
+          "melange",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "melange",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1694035969,
+        "narHash": "sha256-QJnOPSxduX34SAPJJXORukEusOLUe/rpMdOI2qOxnGo=",
+        "owner": "melange-re",
+        "repo": "melange-compiler-libs",
+        "rev": "6e6646c6f8b6e2d785e12b8c38e14af2e8e47893",
+        "type": "github"
+      },
+      "original": {
+        "owner": "melange-re",
+        "repo": "melange-compiler-libs",
+        "type": "github"
+      }
+    },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1687178632,
+        "narHash": "sha256-HS7YR5erss0JCaUijPeyg2XrisEb959FIct3n2TMGbE=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "d90c75e8319d0dd9be67d933d8eb9d0894ec9174",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1694850880,
+        "narHash": "sha256-PQrEK+nqAh2DR3Tz25iwelEe/Na9Fg1X6Y45wqoRS2M=",
+        "owner": "nix-ocaml",
+        "repo": "nix-overlays",
+        "rev": "c5d467da9ab70c8afdffafa6707bd38772386830",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-ocaml",
+        "repo": "nix-overlays",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1694783612,
+        "narHash": "sha256-9XhxTN/PcWap9EIKFXp7t9KpAj2o2sUwet8ly44tH0Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3b1f3712a415f6bf8352f3bb457973daa8bce91d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3b1f3712a415f6bf8352f3bb457973daa8bce91d",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "melange": "melange",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = "server-reason-react";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs = {
+      url = "github:nix-ocaml/nix-overlays";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+    melange = {
+      # this should match the pinned version in the Makefile
+      url = "github:melange-re/melange?rev=a01735398b5df5b90f0a567dd660847ae0e9da48";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+  };
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , melange
+    }:
+    (flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages."${system}".appendOverlays [
+        melange.overlays.default
+        (self: super: {
+          ocamlPackages = super.ocaml-ng.ocamlPackages_5_1;
+        })
+      ];
+      inherit (pkgs) ocamlPackages;
+    in
+    with ocamlPackages;
+    rec {
+      devShells.default = pkgs.mkShell {
+        buildInputs = [
+          lwt
+          lwt_ppx
+          ocamlPackages.melange
+          ocaml_pcre
+          alcotest
+          alcotest-lwt
+          fmt
+          ppxlib
+          reason-react
+        ];
+        nativeBuildInputs = [
+          findlib
+          ocaml
+          ocaml-lsp
+          reason
+          dune_3
+          reason-native.refmterr
+          ocamlformat
+        ];
+        OCAMLRUNPARAM = "b";
+      };
+    }));
+}


### PR DESCRIPTION
This adds an initial nix flake only supporting a local dev shell. A future pr will modify it to add packages and ci support, as is done in the reason-react repo.