### PR TITLE
reorder style props

### DIFF
--- a/packages/reactDom/src/reactDOMStyle.ml
+++ b/packages/reactDom/src/reactDOMStyle.ml
@@ -349,356 +349,366 @@ let make
   ?(rubyMerge : string option)
   ?(rubyPosition : string option)
   () =
-  (* The order of addition matters since it will need to be the same order as
-  the JS object defined in https://github.com/reasonml/reason-react/blob/3327dc214905c4b2863b19807aaac375633645cf/src/dOMStyle.re *)
+  (* 
+     The order of addition matters since it will need to be the same order as
+  the JS object defined in https://github.com/reasonml/reason-react/blob/3327dc214905c4b2863b19807aaac375633645cf/src/dOMStyle.re 
+
+  The following shell script can be run from the reason-react repository to generate the calls to "add" below:
+
+  for style in $(cat src/dOMStyle.re | grep "~" | sed 's/.*\~\([^:]*\):.*/\1/'); do
+    dashed=$(echo "$style" | sed 's/\([A-Z]\)/-\L\1/g')
+    echo "|> add \"$dashed\" $style"
+  done
+
+  *)
   []
   |> add "azimuth" azimuth
-|> add "background" background
-|> add "background-attachment" backgroundAttachment
-|> add "background-color" backgroundColor
-|> add "background-image" backgroundImage
-|> add "background-position" backgroundPosition
-|> add "background-repeat" backgroundRepeat
-|> add "border" border
-|> add "border-collapse" borderCollapse
-|> add "border-color" borderColor
-|> add "border-spacing" borderSpacing
-|> add "border-style" borderStyle
-|> add "border-top" borderTop
-|> add "border-right" borderRight
-|> add "border-bottom" borderBottom
-|> add "border-left" borderLeft
-|> add "border-top-color" borderTopColor
-|> add "border-right-color" borderRightColor
-|> add "border-bottom-color" borderBottomColor
-|> add "border-left-color" borderLeftColor
-|> add "border-top-style" borderTopStyle
-|> add "border-right-style" borderRightStyle
-|> add "border-bottom-style" borderBottomStyle
-|> add "border-left-style" borderLeftStyle
-|> add "border-top-width" borderTopWidth
-|> add "border-right-width" borderRightWidth
-|> add "border-bottom-width" borderBottomWidth
-|> add "border-left-width" borderLeftWidth
-|> add "border-width" borderWidth
-|> add "bottom" bottom
-|> add "caption-side" captionSide
-|> add "clear" clear
-|> add "clip" clip
-|> add "color" color
-|> add "content" content
-|> add "counter-increment" counterIncrement
-|> add "counter-reset" counterReset
-|> add "cue" cue
-|> add "cue-after" cueAfter
-|> add "cue-before" cueBefore
-|> add "cursor" cursor
-|> add "direction" direction
-|> add "display" display
-|> add "elevation" elevation
-|> add "empty-cells" emptyCells
-|> add "float" float
-|> add "font" font
-|> add "font-family" fontFamily
-|> add "font-size" fontSize
-|> add "font-size-adjust" fontSizeAdjust
-|> add "font-stretch" fontStretch
-|> add "font-style" fontStyle
-|> add "font-variant" fontVariant
-|> add "font-weight" fontWeight
-|> add "height" height
-|> add "left" left
-|> add "letter-spacing" letterSpacing
-|> add "line-height" lineHeight
-|> add "list-style" listStyle
-|> add "list-style-image" listStyleImage
-|> add "list-style-position" listStylePosition
-|> add "list-style-type" listStyleType
-|> add "margin" margin
-|> add "margin-top" marginTop
-|> add "margin-right" marginRight
-|> add "margin-bottom" marginBottom
-|> add "margin-left" marginLeft
-|> add "marker-offset" markerOffset
-|> add "marks" marks
-|> add "max-height" maxHeight
-|> add "max-width" maxWidth
-|> add "min-height" minHeight
-|> add "min-width" minWidth
-|> add "orphans" orphans
-|> add "outline" outline
-|> add "outline-color" outlineColor
-|> add "outline-style" outlineStyle
-|> add "outline-width" outlineWidth
-|> add "overflow" overflow
-|> add "overflow-x" overflowX
-|> add "overflow-y" overflowY
-|> add "padding" padding
-|> add "padding-top" paddingTop
-|> add "padding-right" paddingRight
-|> add "padding-bottom" paddingBottom
-|> add "padding-left" paddingLeft
-|> add "page" page
-|> add "page-break-after" pageBreakAfter
-|> add "page-break-before" pageBreakBefore
-|> add "page-break-inside" pageBreakInside
-|> add "pause" pause
-|> add "pause-after" pauseAfter
-|> add "pause-before" pauseBefore
-|> add "pitch" pitch
-|> add "pitch-range" pitchRange
-|> add "play-during" playDuring
-|> add "position" position
-|> add "quotes" quotes
-|> add "richness" richness
-|> add "right" right
-|> add "size" size
-|> add "speak" speak
-|> add "speak-header" speakHeader
-|> add "speak-numeral" speakNumeral
-|> add "speak-punctuation" speakPunctuation
-|> add "speech-rate" speechRate
-|> add "stress" stress
-|> add "table-layout" tableLayout
-|> add "text-align" textAlign
-|> add "text-decoration" textDecoration
-|> add "text-indent" textIndent
-|> add "text-shadow" textShadow
-|> add "text-transform" textTransform
-|> add "top" top
-|> add "unicode-bidi" unicodeBidi
-|> add "vertical-align" verticalAlign
-|> add "visibility" visibility
-|> add "voice-family" voiceFamily
-|> add "volume" volume
-|> add "white-space" whiteSpace
-|> add "widows" widows
-|> add "width" width
-|> add "word-spacing" wordSpacing
-|> add "z-index" zIndex
-|> add "opacity" opacity
-|> add "background-origin" backgroundOrigin
-|> add "background-size" backgroundSize
-|> add "background-clip" backgroundClip
-|> add "border-radius" borderRadius
-|> add "border-top-left-radius" borderTopLeftRadius
-|> add "border-top-right-radius" borderTopRightRadius
-|> add "border-bottom-left-radius" borderBottomLeftRadius
-|> add "border-bottom-right-radius" borderBottomRightRadius
-|> add "border-image" borderImage
-|> add "border-image-source" borderImageSource
-|> add "border-image-slice" borderImageSlice
-|> add "border-image-width" borderImageWidth
-|> add "border-image-outset" borderImageOutset
-|> add "border-image-repeat" borderImageRepeat
-|> add "box-shadow" boxShadow
-|> add "columns" columns
-|> add "column-count" columnCount
-|> add "column-fill" columnFill
-|> add "column-gap" columnGap
-|> add "column-rule" columnRule
-|> add "column-rule-color" columnRuleColor
-|> add "column-rule-style" columnRuleStyle
-|> add "column-rule-width" columnRuleWidth
-|> add "column-span" columnSpan
-|> add "column-width" columnWidth
-|> add "break-after" breakAfter
-|> add "break-before" breakBefore
-|> add "break-inside" breakInside
-|> add "rest" rest
-|> add "rest-after" restAfter
-|> add "rest-before" restBefore
-|> add "speak-as" speakAs
-|> add "voice-balance" voiceBalance
-|> add "voice-duration" voiceDuration
-|> add "voice-pitch" voicePitch
-|> add "voice-range" voiceRange
-|> add "voice-rate" voiceRate
-|> add "voice-stress" voiceStress
-|> add "voice-volume" voiceVolume
-|> add "object-fit" objectFit
-|> add "object-position" objectPosition
-|> add "image-resolution" imageResolution
-|> add "image-orientation" imageOrientation
-|> add "align-content" alignContent
-|> add "align-items" alignItems
-|> add "align-self" alignSelf
-|> add "flex" flex
-|> add "flex-basis" flexBasis
-|> add "flex-direction" flexDirection
-|> add "flex-flow" flexFlow
-|> add "flex-grow" flexGrow
-|> add "flex-shrink" flexShrink
-|> add "flex-wrap" flexWrap
-|> add "justify-content" justifyContent
-|> add "order" order
-|> add "text-decoration-color" textDecorationColor
-|> add "text-decoration-line" textDecorationLine
-|> add "text-decoration-skip" textDecorationSkip
-|> add "text-decoration-style" textDecorationStyle
-|> add "text-emphasis" textEmphasis
-|> add "text-emphasis-color" textEmphasisColor
-|> add "text-emphasis-position" textEmphasisPosition
-|> add "text-emphasis-style" textEmphasisStyle
-|> add "text-underline-position" textUnderlinePosition
-|> add "font-feature-settings" fontFeatureSettings
-|> add "font-kerning" fontKerning
-|> add "font-language-override" fontLanguageOverride
-|> add "font-synthesis" fontSynthesis
-|> add "fornt-variant-alternates" forntVariantAlternates
-|> add "font-variant-caps" fontVariantCaps
-|> add "font-variant-east-asian" fontVariantEastAsian
-|> add "font-variant-ligatures" fontVariantLigatures
-|> add "font-variant-numeric" fontVariantNumeric
-|> add "font-variant-position" fontVariantPosition
-|> add "all" all
-|> add "glyph-orientation-vertical" glyphOrientationVertical
-|> add "text-combine-upright" textCombineUpright
-|> add "text-orientation" textOrientation
-|> add "writing-mode" writingMode
-|> add "shape-image-threshold" shapeImageThreshold
-|> add "shape-margin" shapeMargin
-|> add "shape-outside" shapeOutside
-|> add "clip-path" clipPath
-|> add "clip-rule" clipRule
-|> add "mask" mask
-|> add "mask-border" maskBorder
-|> add "mask-border-mode" maskBorderMode
-|> add "mask-border-outset" maskBorderOutset
-|> add "mask-border-repeat" maskBorderRepeat
-|> add "mask-border-slice" maskBorderSlice
-|> add "mask-border-source" maskBorderSource
-|> add "mask-border-width" maskBorderWidth
-|> add "mask-clip" maskClip
-|> add "mask-composite" maskComposite
-|> add "mask-image" maskImage
-|> add "mask-mode" maskMode
-|> add "mask-origin" maskOrigin
-|> add "mask-position" maskPosition
-|> add "mask-repeat" maskRepeat
-|> add "mask-size" maskSize
-|> add "mask-type" maskType
-|> add "background-blend-mode" backgroundBlendMode
-|> add "isolation" isolation
-|> add "mix-blend-mode" mixBlendMode
-|> add "box-decoration-break" boxDecorationBreak
-|> add "box-sizing" boxSizing
-|> add "caret-color" caretColor
-|> add "nav-down" navDown
-|> add "nav-left" navLeft
-|> add "nav-right" navRight
-|> add "nav-up" navUp
-|> add "outline-offset" outlineOffset
-|> add "resize" resize
-|> add "text-overflow" textOverflow
-|> add "grid" grid
-|> add "grid-area" gridArea
-|> add "grid-auto-columns" gridAutoColumns
-|> add "grid-auto-flow" gridAutoFlow
-|> add "grid-auto-rows" gridAutoRows
-|> add "grid-column" gridColumn
-|> add "grid-column-end" gridColumnEnd
-|> add "grid-column-gap" gridColumnGap
-|> add "grid-column-start" gridColumnStart
-|> add "grid-gap" gridGap
-|> add "grid-row" gridRow
-|> add "grid-row-end" gridRowEnd
-|> add "grid-row-gap" gridRowGap
-|> add "grid-row-start" gridRowStart
-|> add "grid-template" gridTemplate
-|> add "grid-template-areas" gridTemplateAreas
-|> add "grid-template-columns" gridTemplateColumns
-|> add "grid-template-rows" gridTemplateRows
-|> add "will-change" willChange
-|> add "hanging-punctuation" hangingPunctuation
-|> add "hyphens" hyphens
-|> add "line-break" lineBreak
-|> add "overflow-wrap" overflowWrap
-|> add "tab-size" tabSize
-|> add "text-align-last" textAlignLast
-|> add "text-justify" textJustify
-|> add "word-break" wordBreak
-|> add "word-wrap" wordWrap
-|> add "animation" animation
-|> add "animation-delay" animationDelay
-|> add "animation-direction" animationDirection
-|> add "animation-duration" animationDuration
-|> add "animation-fill-mode" animationFillMode
-|> add "animation-iteration-count" animationIterationCount
-|> add "animation-name" animationName
-|> add "animation-play-state" animationPlayState
-|> add "animation-timing-function" animationTimingFunction
-|> add "transition" transition
-|> add "transition-delay" transitionDelay
-|> add "transition-duration" transitionDuration
-|> add "transition-property" transitionProperty
-|> add "transition-timing-function" transitionTimingFunction
-|> add "backface-visibility" backfaceVisibility
-|> add "perspective" perspective
-|> add "perspective-origin" perspectiveOrigin
-|> add "transform" transform
-|> add "transform-origin" transformOrigin
-|> add "transform-style" transformStyle
-|> add "justify-items" justifyItems
-|> add "justify-self" justifySelf
-|> add "place-content" placeContent
-|> add "place-items" placeItems
-|> add "place-self" placeSelf
-|> add "appearance" appearance
-|> add "caret" caret
-|> add "caret-animation" caretAnimation
-|> add "caret-shape" caretShape
-|> add "user-select" userSelect
-|> add "max-lines" maxLines
-|> add "marquee-direction" marqueeDirection
-|> add "marquee-loop" marqueeLoop
-|> add "marquee-speed" marqueeSpeed
-|> add "marquee-style" marqueeStyle
-|> add "overflow-style" overflowStyle
-|> add "rotation" rotation
-|> add "rotation-point" rotationPoint
-|> add "alignment-baseline" alignmentBaseline
-|> add "baseline-shift" baselineShift
-|> add "clip" clip
-|> add "clip-path" clipPath
-|> add "clip-rule" clipRule
-|> add "color-interpolation" colorInterpolation
-|> add "color-interpolation-filters" colorInterpolationFilters
-|> add "color-profile" colorProfile
-|> add "color-rendering" colorRendering
-|> add "cursor" cursor
-|> add "dominant-baseline" dominantBaseline
-|> add "fill" fill
-|> add "fill-opacity" fillOpacity
-|> add "fill-rule" fillRule
-|> add "filter" filter
-|> add "flood-color" floodColor
-|> add "flood-opacity" floodOpacity
-|> add "glyph-orientation-horizontal" glyphOrientationHorizontal
-|> add "glyph-orientation-vertical" glyphOrientationVertical
-|> add "image-rendering" imageRendering
-|> add "kerning" kerning
-|> add "lighting-color" lightingColor
-|> add "marker-end" markerEnd
-|> add "marker-mid" markerMid
-|> add "marker-start" markerStart
-|> add "pointer-events" pointerEvents
-|> add "shape-rendering" shapeRendering
-|> add "stop-color" stopColor
-|> add "stop-opacity" stopOpacity
-|> add "stroke" stroke
-|> add "stroke-dasharray" strokeDasharray
-|> add "stroke-dashoffset" strokeDashoffset
-|> add "stroke-linecap" strokeLinecap
-|> add "stroke-linejoin" strokeLinejoin
-|> add "stroke-miterlimit" strokeMiterlimit
-|> add "stroke-opacity" strokeOpacity
-|> add "stroke-width" strokeWidth
-|> add "text-anchor" textAnchor
-|> add "text-rendering" textRendering
-|> add "ruby-align" rubyAlign
-|> add "ruby-merge" rubyMerge
-|> add "ruby-position" rubyPosition
+  |> add "background" background
+  |> add "background-attachment" backgroundAttachment
+  |> add "background-color" backgroundColor
+  |> add "background-image" backgroundImage
+  |> add "background-position" backgroundPosition
+  |> add "background-repeat" backgroundRepeat
+  |> add "border" border
+  |> add "border-collapse" borderCollapse
+  |> add "border-color" borderColor
+  |> add "border-spacing" borderSpacing
+  |> add "border-style" borderStyle
+  |> add "border-top" borderTop
+  |> add "border-right" borderRight
+  |> add "border-bottom" borderBottom
+  |> add "border-left" borderLeft
+  |> add "border-top-color" borderTopColor
+  |> add "border-right-color" borderRightColor
+  |> add "border-bottom-color" borderBottomColor
+  |> add "border-left-color" borderLeftColor
+  |> add "border-top-style" borderTopStyle
+  |> add "border-right-style" borderRightStyle
+  |> add "border-bottom-style" borderBottomStyle
+  |> add "border-left-style" borderLeftStyle
+  |> add "border-top-width" borderTopWidth
+  |> add "border-right-width" borderRightWidth
+  |> add "border-bottom-width" borderBottomWidth
+  |> add "border-left-width" borderLeftWidth
+  |> add "border-width" borderWidth
+  |> add "bottom" bottom
+  |> add "caption-side" captionSide
+  |> add "clear" clear
+  |> add "clip" clip
+  |> add "color" color
+  |> add "content" content
+  |> add "counter-increment" counterIncrement
+  |> add "counter-reset" counterReset
+  |> add "cue" cue
+  |> add "cue-after" cueAfter
+  |> add "cue-before" cueBefore
+  |> add "cursor" cursor
+  |> add "direction" direction
+  |> add "display" display
+  |> add "elevation" elevation
+  |> add "empty-cells" emptyCells
+  |> add "float" float
+  |> add "font" font
+  |> add "font-family" fontFamily
+  |> add "font-size" fontSize
+  |> add "font-size-adjust" fontSizeAdjust
+  |> add "font-stretch" fontStretch
+  |> add "font-style" fontStyle
+  |> add "font-variant" fontVariant
+  |> add "font-weight" fontWeight
+  |> add "height" height
+  |> add "left" left
+  |> add "letter-spacing" letterSpacing
+  |> add "line-height" lineHeight
+  |> add "list-style" listStyle
+  |> add "list-style-image" listStyleImage
+  |> add "list-style-position" listStylePosition
+  |> add "list-style-type" listStyleType
+  |> add "margin" margin
+  |> add "margin-top" marginTop
+  |> add "margin-right" marginRight
+  |> add "margin-bottom" marginBottom
+  |> add "margin-left" marginLeft
+  |> add "marker-offset" markerOffset
+  |> add "marks" marks
+  |> add "max-height" maxHeight
+  |> add "max-width" maxWidth
+  |> add "min-height" minHeight
+  |> add "min-width" minWidth
+  |> add "orphans" orphans
+  |> add "outline" outline
+  |> add "outline-color" outlineColor
+  |> add "outline-style" outlineStyle
+  |> add "outline-width" outlineWidth
+  |> add "overflow" overflow
+  |> add "overflow-x" overflowX
+  |> add "overflow-y" overflowY
+  |> add "padding" padding
+  |> add "padding-top" paddingTop
+  |> add "padding-right" paddingRight
+  |> add "padding-bottom" paddingBottom
+  |> add "padding-left" paddingLeft
+  |> add "page" page
+  |> add "page-break-after" pageBreakAfter
+  |> add "page-break-before" pageBreakBefore
+  |> add "page-break-inside" pageBreakInside
+  |> add "pause" pause
+  |> add "pause-after" pauseAfter
+  |> add "pause-before" pauseBefore
+  |> add "pitch" pitch
+  |> add "pitch-range" pitchRange
+  |> add "play-during" playDuring
+  |> add "position" position
+  |> add "quotes" quotes
+  |> add "richness" richness
+  |> add "right" right
+  |> add "size" size
+  |> add "speak" speak
+  |> add "speak-header" speakHeader
+  |> add "speak-numeral" speakNumeral
+  |> add "speak-punctuation" speakPunctuation
+  |> add "speech-rate" speechRate
+  |> add "stress" stress
+  |> add "table-layout" tableLayout
+  |> add "text-align" textAlign
+  |> add "text-decoration" textDecoration
+  |> add "text-indent" textIndent
+  |> add "text-shadow" textShadow
+  |> add "text-transform" textTransform
+  |> add "top" top
+  |> add "unicode-bidi" unicodeBidi
+  |> add "vertical-align" verticalAlign
+  |> add "visibility" visibility
+  |> add "voice-family" voiceFamily
+  |> add "volume" volume
+  |> add "white-space" whiteSpace
+  |> add "widows" widows
+  |> add "width" width
+  |> add "word-spacing" wordSpacing
+  |> add "z-index" zIndex
+  |> add "opacity" opacity
+  |> add "background-origin" backgroundOrigin
+  |> add "background-size" backgroundSize
+  |> add "background-clip" backgroundClip
+  |> add "border-radius" borderRadius
+  |> add "border-top-left-radius" borderTopLeftRadius
+  |> add "border-top-right-radius" borderTopRightRadius
+  |> add "border-bottom-left-radius" borderBottomLeftRadius
+  |> add "border-bottom-right-radius" borderBottomRightRadius
+  |> add "border-image" borderImage
+  |> add "border-image-source" borderImageSource
+  |> add "border-image-slice" borderImageSlice
+  |> add "border-image-width" borderImageWidth
+  |> add "border-image-outset" borderImageOutset
+  |> add "border-image-repeat" borderImageRepeat
+  |> add "box-shadow" boxShadow
+  |> add "columns" columns
+  |> add "column-count" columnCount
+  |> add "column-fill" columnFill
+  |> add "column-gap" columnGap
+  |> add "column-rule" columnRule
+  |> add "column-rule-color" columnRuleColor
+  |> add "column-rule-style" columnRuleStyle
+  |> add "column-rule-width" columnRuleWidth
+  |> add "column-span" columnSpan
+  |> add "column-width" columnWidth
+  |> add "break-after" breakAfter
+  |> add "break-before" breakBefore
+  |> add "break-inside" breakInside
+  |> add "rest" rest
+  |> add "rest-after" restAfter
+  |> add "rest-before" restBefore
+  |> add "speak-as" speakAs
+  |> add "voice-balance" voiceBalance
+  |> add "voice-duration" voiceDuration
+  |> add "voice-pitch" voicePitch
+  |> add "voice-range" voiceRange
+  |> add "voice-rate" voiceRate
+  |> add "voice-stress" voiceStress
+  |> add "voice-volume" voiceVolume
+  |> add "object-fit" objectFit
+  |> add "object-position" objectPosition
+  |> add "image-resolution" imageResolution
+  |> add "image-orientation" imageOrientation
+  |> add "align-content" alignContent
+  |> add "align-items" alignItems
+  |> add "align-self" alignSelf
+  |> add "flex" flex
+  |> add "flex-basis" flexBasis
+  |> add "flex-direction" flexDirection
+  |> add "flex-flow" flexFlow
+  |> add "flex-grow" flexGrow
+  |> add "flex-shrink" flexShrink
+  |> add "flex-wrap" flexWrap
+  |> add "justify-content" justifyContent
+  |> add "order" order
+  |> add "text-decoration-color" textDecorationColor
+  |> add "text-decoration-line" textDecorationLine
+  |> add "text-decoration-skip" textDecorationSkip
+  |> add "text-decoration-style" textDecorationStyle
+  |> add "text-emphasis" textEmphasis
+  |> add "text-emphasis-color" textEmphasisColor
+  |> add "text-emphasis-position" textEmphasisPosition
+  |> add "text-emphasis-style" textEmphasisStyle
+  |> add "text-underline-position" textUnderlinePosition
+  |> add "font-feature-settings" fontFeatureSettings
+  |> add "font-kerning" fontKerning
+  |> add "font-language-override" fontLanguageOverride
+  |> add "font-synthesis" fontSynthesis
+  |> add "fornt-variant-alternates" forntVariantAlternates
+  |> add "font-variant-caps" fontVariantCaps
+  |> add "font-variant-east-asian" fontVariantEastAsian
+  |> add "font-variant-ligatures" fontVariantLigatures
+  |> add "font-variant-numeric" fontVariantNumeric
+  |> add "font-variant-position" fontVariantPosition
+  |> add "all" all
+  |> add "glyph-orientation-vertical" glyphOrientationVertical
+  |> add "text-combine-upright" textCombineUpright
+  |> add "text-orientation" textOrientation
+  |> add "writing-mode" writingMode
+  |> add "shape-image-threshold" shapeImageThreshold
+  |> add "shape-margin" shapeMargin
+  |> add "shape-outside" shapeOutside
+  |> add "clip-path" clipPath
+  |> add "clip-rule" clipRule
+  |> add "mask" mask
+  |> add "mask-border" maskBorder
+  |> add "mask-border-mode" maskBorderMode
+  |> add "mask-border-outset" maskBorderOutset
+  |> add "mask-border-repeat" maskBorderRepeat
+  |> add "mask-border-slice" maskBorderSlice
+  |> add "mask-border-source" maskBorderSource
+  |> add "mask-border-width" maskBorderWidth
+  |> add "mask-clip" maskClip
+  |> add "mask-composite" maskComposite
+  |> add "mask-image" maskImage
+  |> add "mask-mode" maskMode
+  |> add "mask-origin" maskOrigin
+  |> add "mask-position" maskPosition
+  |> add "mask-repeat" maskRepeat
+  |> add "mask-size" maskSize
+  |> add "mask-type" maskType
+  |> add "background-blend-mode" backgroundBlendMode
+  |> add "isolation" isolation
+  |> add "mix-blend-mode" mixBlendMode
+  |> add "box-decoration-break" boxDecorationBreak
+  |> add "box-sizing" boxSizing
+  |> add "caret-color" caretColor
+  |> add "nav-down" navDown
+  |> add "nav-left" navLeft
+  |> add "nav-right" navRight
+  |> add "nav-up" navUp
+  |> add "outline-offset" outlineOffset
+  |> add "resize" resize
+  |> add "text-overflow" textOverflow
+  |> add "grid" grid
+  |> add "grid-area" gridArea
+  |> add "grid-auto-columns" gridAutoColumns
+  |> add "grid-auto-flow" gridAutoFlow
+  |> add "grid-auto-rows" gridAutoRows
+  |> add "grid-column" gridColumn
+  |> add "grid-column-end" gridColumnEnd
+  |> add "grid-column-gap" gridColumnGap
+  |> add "grid-column-start" gridColumnStart
+  |> add "grid-gap" gridGap
+  |> add "grid-row" gridRow
+  |> add "grid-row-end" gridRowEnd
+  |> add "grid-row-gap" gridRowGap
+  |> add "grid-row-start" gridRowStart
+  |> add "grid-template" gridTemplate
+  |> add "grid-template-areas" gridTemplateAreas
+  |> add "grid-template-columns" gridTemplateColumns
+  |> add "grid-template-rows" gridTemplateRows
+  |> add "will-change" willChange
+  |> add "hanging-punctuation" hangingPunctuation
+  |> add "hyphens" hyphens
+  |> add "line-break" lineBreak
+  |> add "overflow-wrap" overflowWrap
+  |> add "tab-size" tabSize
+  |> add "text-align-last" textAlignLast
+  |> add "text-justify" textJustify
+  |> add "word-break" wordBreak
+  |> add "word-wrap" wordWrap
+  |> add "animation" animation
+  |> add "animation-delay" animationDelay
+  |> add "animation-direction" animationDirection
+  |> add "animation-duration" animationDuration
+  |> add "animation-fill-mode" animationFillMode
+  |> add "animation-iteration-count" animationIterationCount
+  |> add "animation-name" animationName
+  |> add "animation-play-state" animationPlayState
+  |> add "animation-timing-function" animationTimingFunction
+  |> add "transition" transition
+  |> add "transition-delay" transitionDelay
+  |> add "transition-duration" transitionDuration
+  |> add "transition-property" transitionProperty
+  |> add "transition-timing-function" transitionTimingFunction
+  |> add "backface-visibility" backfaceVisibility
+  |> add "perspective" perspective
+  |> add "perspective-origin" perspectiveOrigin
+  |> add "transform" transform
+  |> add "transform-origin" transformOrigin
+  |> add "transform-style" transformStyle
+  |> add "justify-items" justifyItems
+  |> add "justify-self" justifySelf
+  |> add "place-content" placeContent
+  |> add "place-items" placeItems
+  |> add "place-self" placeSelf
+  |> add "appearance" appearance
+  |> add "caret" caret
+  |> add "caret-animation" caretAnimation
+  |> add "caret-shape" caretShape
+  |> add "user-select" userSelect
+  |> add "max-lines" maxLines
+  |> add "marquee-direction" marqueeDirection
+  |> add "marquee-loop" marqueeLoop
+  |> add "marquee-speed" marqueeSpeed
+  |> add "marquee-style" marqueeStyle
+  |> add "overflow-style" overflowStyle
+  |> add "rotation" rotation
+  |> add "rotation-point" rotationPoint
+  |> add "alignment-baseline" alignmentBaseline
+  |> add "baseline-shift" baselineShift
+  |> add "clip" clip
+  |> add "clip-path" clipPath
+  |> add "clip-rule" clipRule
+  |> add "color-interpolation" colorInterpolation
+  |> add "color-interpolation-filters" colorInterpolationFilters
+  |> add "color-profile" colorProfile
+  |> add "color-rendering" colorRendering
+  |> add "cursor" cursor
+  |> add "dominant-baseline" dominantBaseline
+  |> add "fill" fill
+  |> add "fill-opacity" fillOpacity
+  |> add "fill-rule" fillRule
+  |> add "filter" filter
+  |> add "flood-color" floodColor
+  |> add "flood-opacity" floodOpacity
+  |> add "glyph-orientation-horizontal" glyphOrientationHorizontal
+  |> add "glyph-orientation-vertical" glyphOrientationVertical
+  |> add "image-rendering" imageRendering
+  |> add "kerning" kerning
+  |> add "lighting-color" lightingColor
+  |> add "marker-end" markerEnd
+  |> add "marker-mid" markerMid
+  |> add "marker-start" markerStart
+  |> add "pointer-events" pointerEvents
+  |> add "shape-rendering" shapeRendering
+  |> add "stop-color" stopColor
+  |> add "stop-opacity" stopOpacity
+  |> add "stroke" stroke
+  |> add "stroke-dasharray" strokeDasharray
+  |> add "stroke-dashoffset" strokeDashoffset
+  |> add "stroke-linecap" strokeLinecap
+  |> add "stroke-linejoin" strokeLinejoin
+  |> add "stroke-miterlimit" strokeMiterlimit
+  |> add "stroke-opacity" strokeOpacity
+  |> add "stroke-width" strokeWidth
+  |> add "text-anchor" textAnchor
+  |> add "text-rendering" textRendering
+  |> add "ruby-align" rubyAlign
+  |> add "ruby-merge" rubyMerge
+  |> add "ruby-position" rubyPosition
 [@@@ocamlformat "enable"]
 
 let to_string (styles : t) : string =

--- a/packages/reactDom/src/reactDOMStyle.ml
+++ b/packages/reactDom/src/reactDOMStyle.ml
@@ -352,363 +352,369 @@ let make
   (* The order of addition matters since it will need to be the same order as
   the JS object defined in https://github.com/reasonml/reason-react/blob/3327dc214905c4b2863b19807aaac375633645cf/src/dOMStyle.re *)
   []
-  |> add "z-index" zIndex
-  |> add "writing-mode" writingMode
-  |> add "word-wrap" wordWrap
-  |> add "word-spacing" wordSpacing
-  |> add "word-break" wordBreak
-  |> add "will-change" willChange
-  |> add "width" width
-  |> add "widows" widows
-  |> add "white-space" whiteSpace
-  |> add "volume" volume
-  |> add "voice-volume" voiceVolume
-  |> add "voice-stress" voiceStress
-  |> add "voice-rate" voiceRate
-  |> add "voice-range" voiceRange
-  |> add "voice-pitch" voicePitch
-  |> add "voice-family" voiceFamily
-  |> add "voice-duration" voiceDuration
-  |> add "voice-balance" voiceBalance
-  |> add "visibility" visibility
-  |> add "vertical-align" verticalAlign
-  |> add "user-select" userSelect
-  |> add "unicode-bidi" unicodeBidi
-  |> add "transition" transition
-  |> add "transition-timing-function" transitionTimingFunction
-  |> add "transition-property" transitionProperty
-  |> add "transition-duration" transitionDuration
-  |> add "transition-delay" transitionDelay
-  |> add "transform" transform
-  |> add "transform-style" transformStyle
-  |> add "transform-origin" transformOrigin
-  |> add "top" top
-  |> add "text-underline-position" textUnderlinePosition
-  |> add "text-transform" textTransform
-  |> add "text-shadow" textShadow
-  |> add "text-rendering" textRendering
-  |> add "text-overflow" textOverflow
-  |> add "text-orientation" textOrientation
-  |> add "text-justify" textJustify
-  |> add "text-indent" textIndent
-  |> add "text-emphasis" textEmphasis
-  |> add "text-emphasis-style" textEmphasisStyle
-  |> add "text-emphasis-position" textEmphasisPosition
-  |> add "text-emphasis-color" textEmphasisColor
-  |> add "text-decoration" textDecoration
-  |> add "text-decoration-style" textDecorationStyle
-  |> add "text-decoration-skip" textDecorationSkip
-  |> add "text-decoration-line" textDecorationLine
-  |> add "text-decoration-color" textDecorationColor
-  |> add "text-combine-upright" textCombineUpright
-  |> add "text-anchor" textAnchor
-  |> add "text-align" textAlign
-  |> add "text-align-last" textAlignLast
-  |> add "table-layout" tableLayout
-  |> add "stroke" stroke |> add "tab-size" tabSize
-  |> add "stroke-width" strokeWidth
-  |> add "stroke-opacity" strokeOpacity
-  |> add "stroke-miterlimit" strokeMiterlimit
-  |> add "stroke-linejoin" strokeLinejoin
-  |> add "stroke-linecap" strokeLinecap
-  |> add "stroke-dashoffset" strokeDashoffset
-  |> add "stroke-dasharray" strokeDasharray
-  |> add "stress" stress
-  |> add "stop-opacity" stopOpacity
-  |> add "stop-color" stopColor
-  |> add "speech-rate" speechRate
-  |> add "speak" speak
-  |> add "speak-punctuation" speakPunctuation
-  |> add "speak-numeral" speakNumeral
-  |> add "speak-header" speakHeader
-  |> add "size" size |> add "speak-as" speakAs
-  |> add "shape-rendering" shapeRendering
-  |> add "shape-outside" shapeOutside
-  |> add "shape-margin" shapeMargin
-  |> add "shape-image-threshold" shapeImageThreshold
-  |> add "ruby-position" rubyPosition
-  |> add "ruby-merge" rubyMerge
-  |> add "ruby-align" rubyAlign
-  |> add "rotation" rotation
-  |> add "rotation-point" rotationPoint
-  |> add "right" right
-  |> add "richness" richness
-  |> add "rest" rest
-  |> add "rest-before" restBefore
-  |> add "rest-after" restAfter
-  |> add "resize" resize
-  |> add "quotes" quotes
-  |> add "position" position
-  |> add "pointer-events" pointerEvents
-  |> add "play-during" playDuring
-  |> add "place-self" placeSelf
-  |> add "place-items" placeItems
-  |> add "place-content" placeContent
-  |> add "pitch" pitch
-  |> add "pitch-range" pitchRange
-  |> add "perspective" perspective
-  |> add "perspective-origin" perspectiveOrigin
-  |> add "pause" pause
-  |> add "pause-before" pauseBefore
-  |> add "pause-after" pauseAfter
-  |> add "page" page
-  |> add "page-break-inside" pageBreakInside
-  |> add "page-break-before" pageBreakBefore
-  |> add "page-break-after" pageBreakAfter
-  |> add "padding" padding
-  |> add "padding-top" paddingTop
-  |> add "padding-right" paddingRight
-  |> add "padding-left" paddingLeft
-  |> add "padding-bottom" paddingBottom
-  |> add "overflow" overflow
-  |> add "overflow-y" overflowY
-  |> add "overflow-x" overflowX
-  |> add "overflow-wrap" overflowWrap
-  |> add "overflow-style" overflowStyle
-  |> add "outline" outline
-  |> add "outline-width" outlineWidth
-  |> add "outline-style" outlineStyle
-  |> add "outline-offset" outlineOffset
-  |> add "outline-color" outlineColor
-  |> add "orphans" orphans
-  |> add "order" order
-  |> add "opacity" opacity
-  |> add "object-position" objectPosition
-  |> add "object-fit" objectFit
-  |> add "nav-up" navUp
-  |> add "nav-right" navRight
-  |> add "nav-left" navLeft
-  |> add "nav-down" navDown
-  |> add "mix-blend-mode" mixBlendMode
-  |> add "min-width" minWidth
-  |> add "min-height" minHeight
-  |> add "max-width" maxWidth
-  |> add "max-lines" maxLines
-  |> add "max-height" maxHeight
-  |> add "mask" mask
-  |> add "mask-type" maskType
-  |> add "mask-size" maskSize
-  |> add "mask-repeat" maskRepeat
-  |> add "mask-position" maskPosition
-  |> add "mask-origin" maskOrigin
-  |> add "mask-mode" maskMode
-  |> add "mask-image" maskImage
-  |> add "mask-composite" maskComposite
-  |> add "mask-clip" maskClip
-  |> add "mask-border" maskBorder
-  |> add "mask-border-width" maskBorderWidth
-  |> add "mask-border-source" maskBorderSource
-  |> add "mask-border-slice" maskBorderSlice
-  |> add "mask-border-repeat" maskBorderRepeat
-  |> add "mask-border-outset" maskBorderOutset
-  |> add "mask-border-mode" maskBorderMode
-  |> add "marquee-style" marqueeStyle
-  |> add "marquee-speed" marqueeSpeed
-  |> add "marquee-loop" marqueeLoop
-  |> add "marquee-direction" marqueeDirection
-  |> add "marks" marks
-  |> add "marker-start" markerStart
-  |> add "marker-offset" markerOffset
-  |> add "marker-mid" markerMid
-  |> add "marker-end" markerEnd
-  |> add "margin" margin
-  |> add "margin-top" marginTop
-  |> add "margin-right" marginRight
-  |> add "margin-left" marginLeft
-  |> add "margin-bottom" marginBottom
-  |> add "list-style" listStyle
-  |> add "list-style-type" listStyleType
-  |> add "list-style-position" listStylePosition
-  |> add "list-style-image" listStyleImage
-  |> add "line-height" lineHeight
-  |> add "line-break" lineBreak
-  |> add "lighting-color" lightingColor
-  |> add "letter-spacing" letterSpacing
-  |> add "left" left
-  |> add "kerning" kerning
-  |> add "justify-self" justifySelf
-  |> add "justify-items" justifyItems
-  |> add "justify-content" justifyContent
-  |> add "isolation" isolation
-  |> add "image-resolution" imageResolution
-  |> add "image-rendering" imageRendering
-  |> add "image-orientation" imageOrientation
-  |> add "hyphens" hyphens
-  |> add "height" height
-  |> add "hanging-punctuation" hangingPunctuation
-  |> add "grid" grid
-  |> add "grid-template" gridTemplate
-  |> add "grid-template-rows" gridTemplateRows
-  |> add "grid-template-columns" gridTemplateColumns
-  |> add "grid-template-areas" gridTemplateAreas
-  |> add "grid-row" gridRow
-  |> add "grid-row-start" gridRowStart
-  |> add "grid-row-gap" gridRowGap
-  |> add "grid-row-end" gridRowEnd
-  |> add "grid-gap" gridGap
-  |> add "grid-column" gridColumn
-  |> add "grid-column-start" gridColumnStart
-  |> add "grid-column-gap" gridColumnGap
-  |> add "grid-column-end" gridColumnEnd
-  |> add "grid-auto-rows" gridAutoRows
-  |> add "grid-auto-flow" gridAutoFlow
-  |> add "grid-auto-columns" gridAutoColumns
-  |> add "grid-area" gridArea
-  |> add "glyph-orientation-vertical" glyphOrientationVertical
-  |> add "glyph-orientation-horizontal" glyphOrientationHorizontal
-  |> add "fornt-variant-alternates" forntVariantAlternates
-  |> add "font" font
-  |> add "font-weight" fontWeight
-  |> add "font-variant" fontVariant
-  |> add "font-variant-position" fontVariantPosition
-  |> add "font-variant-numeric" fontVariantNumeric
-  |> add "font-variant-ligatures" fontVariantLigatures
-  |> add "font-variant-east-asian" fontVariantEastAsian
-  |> add "font-variant-caps" fontVariantCaps
-  |> add "font-synthesis" fontSynthesis
-  |> add "font-style" fontStyle
-  |> add "font-stretch" fontStretch
-  |> add "font-size" fontSize
-  |> add "font-size-adjust" fontSizeAdjust
-  |> add "font-language-override" fontLanguageOverride
-  |> add "font-kerning" fontKerning
-  |> add "font-feature-settings" fontFeatureSettings
-  |> add "font-family" fontFamily
-  |> add "flood-opacity" floodOpacity
-  |> add "flood-color" floodColor
-  |> add "float" float
-  |> add "flex" flex
-  |> add "flex-wrap" flexWrap
-  |> add "flex-shrink" flexShrink
-  |> add "flex-grow" flexGrow
-  |> add "flex-flow" flexFlow
-  |> add "flex-direction" flexDirection
-  |> add "flex-basis" flexBasis
-  |> add "filter" filter
-  |> add "fill" fill
-  |> add "fill-rule" fillRule
-  |> add "fill-opacity" fillOpacity
-  |> add "empty-cells" emptyCells
-  |> add "elevation" elevation
-  |> add "dominant-baseline" dominantBaseline
-  |> add "display" display
-  |> add "direction" direction
-  |> add "cursor" cursor
-  |> add "cue" cue
-  |> add "cue-before" cueBefore
-  |> add "cue-after" cueAfter
-  |> add "counter-reset" counterReset
-  |> add "counter-increment" counterIncrement
-  |> add "content" content
-  |> add "columns" columns
-  |> add "column-width" columnWidth
-  |> add "column-span" columnSpan
-  |> add "column-rule" columnRule
-  |> add "column-rule-width" columnRuleWidth
-  |> add "column-rule-style" columnRuleStyle
-  |> add "column-rule-color" columnRuleColor
-  |> add "column-gap" columnGap
-  |> add "column-fill" columnFill
-  |> add "column-count" columnCount
-  |> add "color" color
-  |> add "color-rendering" colorRendering
-  |> add "color-profile" colorProfile
-  |> add "color-interpolation" colorInterpolation
-  |> add "color-interpolation-filters" colorInterpolationFilters
-  |> add "clip-rule" clipRule
-  |> add "clip-rule" clipRule
-  |> add "clip" clip
-  |> add "caret" caret
-  |> add "clear" clear
-  |> add "clip-path" clipPath
-  |> add "caret-shape" caretShape
-  |> add "caret-color" caretColor
-  |> add "caret-animation" caretAnimation
-  |> add "caption-side" captionSide
-  |> add "break-inside" breakInside
-  |> add "break-before" breakBefore
-  |> add "break-after" breakAfter
-  |> add "box-shadow" boxShadow
-  |> add "box-sizing" boxSizing
-  |> add "box-decoration-break" boxDecorationBreak
-  |> add "border" border
-  |> add "bottom" bottom
-  |> add "border-width" borderWidth
-  |> add "border-top" borderTop
-  |> add "border-top-width" borderTopWidth
-  |> add "border-top-style" borderTopStyle
-  |> add "border-top-right-radius" borderTopRightRadius
-  |> add "border-top-left-radius" borderTopLeftRadius
-  |> add "border-top-color" borderTopColor
-  |> add "border-style" borderStyle
-  |> add "border-spacing" borderSpacing
-  |> add "border-right" borderRight
-  |> add "border-right-width" borderRightWidth
-  |> add "border-right-style" borderRightStyle
-  |> add "border-right-color" borderRightColor
-  |> add "border-radius" borderRadius
-  |> add "border-left" borderLeft
-  |> add "border-left-width" borderLeftWidth
-  |> add "border-left-style" borderLeftStyle
-  |> add "border-left-color" borderLeftColor
-  |> add "border-image" borderImage
-  |> add "border-image-width" borderImageWidth
-  |> add "border-image-source" borderImageSource
-  |> add "border-image-slice" borderImageSlice
-  |> add "border-image-repeat" borderImageRepeat
-  |> add "border-image-outset" borderImageOutset
-  |> add "border-color" borderColor
-  |> add "border-collapse" borderCollapse
-  |> add "border-bottom" borderBottom
-  |> add "border-bottom-width" borderBottomWidth
-  |> add "border-bottom-style" borderBottomStyle
-  |> add "border-bottom-right-radius" borderBottomRightRadius
-  |> add "border-bottom-left-radius" borderBottomLeftRadius
-  |> add "border-bottom-color" borderBottomColor
-  |> add "baseline-shift" baselineShift
-  |> add "background" background
-  |> add "background-size" backgroundSize
-  |> add "background-repeat" backgroundRepeat
-  |> add "background-position" backgroundPosition
-  |> add "background-origin" backgroundOrigin
-  |> add "background-image" backgroundImage
-  |> add "background-color" backgroundColor
-  |> add "background-clip" backgroundClip
-  |> add "background-blend-mode" backgroundBlendMode
-  |> add "background-attachment" backgroundAttachment
-  |> add "backface-visibility" backfaceVisibility
   |> add "azimuth" azimuth
-  |> add "appearance" appearance
-  |> add "animation" animation
-  |> add "animation-timing-function" animationTimingFunction
-  |> add "animation-play-state" animationPlayState
-  |> add "animation-name" animationName
-  |> add "animation-iteration-count" animationIterationCount
-  |> add "animation-fill-mode" animationFillMode
-  |> add "animation-duration" animationDuration
-  |> add "animation-direction" animationDirection
-  |> add "animation-delay" animationDelay
-  |> add "all" all
-  |> add "alignment-baseline" alignmentBaseline
-  |> add "align-self" alignSelf
-  |> add "align-items" alignItems
-  |> add "align-content" alignContent
+|> add "background" background
+|> add "background-attachment" backgroundAttachment
+|> add "background-color" backgroundColor
+|> add "background-image" backgroundImage
+|> add "background-position" backgroundPosition
+|> add "background-repeat" backgroundRepeat
+|> add "border" border
+|> add "border-collapse" borderCollapse
+|> add "border-color" borderColor
+|> add "border-spacing" borderSpacing
+|> add "border-style" borderStyle
+|> add "border-top" borderTop
+|> add "border-right" borderRight
+|> add "border-bottom" borderBottom
+|> add "border-left" borderLeft
+|> add "border-top-color" borderTopColor
+|> add "border-right-color" borderRightColor
+|> add "border-bottom-color" borderBottomColor
+|> add "border-left-color" borderLeftColor
+|> add "border-top-style" borderTopStyle
+|> add "border-right-style" borderRightStyle
+|> add "border-bottom-style" borderBottomStyle
+|> add "border-left-style" borderLeftStyle
+|> add "border-top-width" borderTopWidth
+|> add "border-right-width" borderRightWidth
+|> add "border-bottom-width" borderBottomWidth
+|> add "border-left-width" borderLeftWidth
+|> add "border-width" borderWidth
+|> add "bottom" bottom
+|> add "caption-side" captionSide
+|> add "clear" clear
+|> add "clip" clip
+|> add "color" color
+|> add "content" content
+|> add "counter-increment" counterIncrement
+|> add "counter-reset" counterReset
+|> add "cue" cue
+|> add "cue-after" cueAfter
+|> add "cue-before" cueBefore
+|> add "cursor" cursor
+|> add "direction" direction
+|> add "display" display
+|> add "elevation" elevation
+|> add "empty-cells" emptyCells
+|> add "float" float
+|> add "font" font
+|> add "font-family" fontFamily
+|> add "font-size" fontSize
+|> add "font-size-adjust" fontSizeAdjust
+|> add "font-stretch" fontStretch
+|> add "font-style" fontStyle
+|> add "font-variant" fontVariant
+|> add "font-weight" fontWeight
+|> add "height" height
+|> add "left" left
+|> add "letter-spacing" letterSpacing
+|> add "line-height" lineHeight
+|> add "list-style" listStyle
+|> add "list-style-image" listStyleImage
+|> add "list-style-position" listStylePosition
+|> add "list-style-type" listStyleType
+|> add "margin" margin
+|> add "margin-top" marginTop
+|> add "margin-right" marginRight
+|> add "margin-bottom" marginBottom
+|> add "margin-left" marginLeft
+|> add "marker-offset" markerOffset
+|> add "marks" marks
+|> add "max-height" maxHeight
+|> add "max-width" maxWidth
+|> add "min-height" minHeight
+|> add "min-width" minWidth
+|> add "orphans" orphans
+|> add "outline" outline
+|> add "outline-color" outlineColor
+|> add "outline-style" outlineStyle
+|> add "outline-width" outlineWidth
+|> add "overflow" overflow
+|> add "overflow-x" overflowX
+|> add "overflow-y" overflowY
+|> add "padding" padding
+|> add "padding-top" paddingTop
+|> add "padding-right" paddingRight
+|> add "padding-bottom" paddingBottom
+|> add "padding-left" paddingLeft
+|> add "page" page
+|> add "page-break-after" pageBreakAfter
+|> add "page-break-before" pageBreakBefore
+|> add "page-break-inside" pageBreakInside
+|> add "pause" pause
+|> add "pause-after" pauseAfter
+|> add "pause-before" pauseBefore
+|> add "pitch" pitch
+|> add "pitch-range" pitchRange
+|> add "play-during" playDuring
+|> add "position" position
+|> add "quotes" quotes
+|> add "richness" richness
+|> add "right" right
+|> add "size" size
+|> add "speak" speak
+|> add "speak-header" speakHeader
+|> add "speak-numeral" speakNumeral
+|> add "speak-punctuation" speakPunctuation
+|> add "speech-rate" speechRate
+|> add "stress" stress
+|> add "table-layout" tableLayout
+|> add "text-align" textAlign
+|> add "text-decoration" textDecoration
+|> add "text-indent" textIndent
+|> add "text-shadow" textShadow
+|> add "text-transform" textTransform
+|> add "top" top
+|> add "unicode-bidi" unicodeBidi
+|> add "vertical-align" verticalAlign
+|> add "visibility" visibility
+|> add "voice-family" voiceFamily
+|> add "volume" volume
+|> add "white-space" whiteSpace
+|> add "widows" widows
+|> add "width" width
+|> add "word-spacing" wordSpacing
+|> add "z-index" zIndex
+|> add "opacity" opacity
+|> add "background-origin" backgroundOrigin
+|> add "background-size" backgroundSize
+|> add "background-clip" backgroundClip
+|> add "border-radius" borderRadius
+|> add "border-top-left-radius" borderTopLeftRadius
+|> add "border-top-right-radius" borderTopRightRadius
+|> add "border-bottom-left-radius" borderBottomLeftRadius
+|> add "border-bottom-right-radius" borderBottomRightRadius
+|> add "border-image" borderImage
+|> add "border-image-source" borderImageSource
+|> add "border-image-slice" borderImageSlice
+|> add "border-image-width" borderImageWidth
+|> add "border-image-outset" borderImageOutset
+|> add "border-image-repeat" borderImageRepeat
+|> add "box-shadow" boxShadow
+|> add "columns" columns
+|> add "column-count" columnCount
+|> add "column-fill" columnFill
+|> add "column-gap" columnGap
+|> add "column-rule" columnRule
+|> add "column-rule-color" columnRuleColor
+|> add "column-rule-style" columnRuleStyle
+|> add "column-rule-width" columnRuleWidth
+|> add "column-span" columnSpan
+|> add "column-width" columnWidth
+|> add "break-after" breakAfter
+|> add "break-before" breakBefore
+|> add "break-inside" breakInside
+|> add "rest" rest
+|> add "rest-after" restAfter
+|> add "rest-before" restBefore
+|> add "speak-as" speakAs
+|> add "voice-balance" voiceBalance
+|> add "voice-duration" voiceDuration
+|> add "voice-pitch" voicePitch
+|> add "voice-range" voiceRange
+|> add "voice-rate" voiceRate
+|> add "voice-stress" voiceStress
+|> add "voice-volume" voiceVolume
+|> add "object-fit" objectFit
+|> add "object-position" objectPosition
+|> add "image-resolution" imageResolution
+|> add "image-orientation" imageOrientation
+|> add "align-content" alignContent
+|> add "align-items" alignItems
+|> add "align-self" alignSelf
+|> add "flex" flex
+|> add "flex-basis" flexBasis
+|> add "flex-direction" flexDirection
+|> add "flex-flow" flexFlow
+|> add "flex-grow" flexGrow
+|> add "flex-shrink" flexShrink
+|> add "flex-wrap" flexWrap
+|> add "justify-content" justifyContent
+|> add "order" order
+|> add "text-decoration-color" textDecorationColor
+|> add "text-decoration-line" textDecorationLine
+|> add "text-decoration-skip" textDecorationSkip
+|> add "text-decoration-style" textDecorationStyle
+|> add "text-emphasis" textEmphasis
+|> add "text-emphasis-color" textEmphasisColor
+|> add "text-emphasis-position" textEmphasisPosition
+|> add "text-emphasis-style" textEmphasisStyle
+|> add "text-underline-position" textUnderlinePosition
+|> add "font-feature-settings" fontFeatureSettings
+|> add "font-kerning" fontKerning
+|> add "font-language-override" fontLanguageOverride
+|> add "font-synthesis" fontSynthesis
+|> add "fornt-variant-alternates" forntVariantAlternates
+|> add "font-variant-caps" fontVariantCaps
+|> add "font-variant-east-asian" fontVariantEastAsian
+|> add "font-variant-ligatures" fontVariantLigatures
+|> add "font-variant-numeric" fontVariantNumeric
+|> add "font-variant-position" fontVariantPosition
+|> add "all" all
+|> add "glyph-orientation-vertical" glyphOrientationVertical
+|> add "text-combine-upright" textCombineUpright
+|> add "text-orientation" textOrientation
+|> add "writing-mode" writingMode
+|> add "shape-image-threshold" shapeImageThreshold
+|> add "shape-margin" shapeMargin
+|> add "shape-outside" shapeOutside
+|> add "clip-path" clipPath
+|> add "clip-rule" clipRule
+|> add "mask" mask
+|> add "mask-border" maskBorder
+|> add "mask-border-mode" maskBorderMode
+|> add "mask-border-outset" maskBorderOutset
+|> add "mask-border-repeat" maskBorderRepeat
+|> add "mask-border-slice" maskBorderSlice
+|> add "mask-border-source" maskBorderSource
+|> add "mask-border-width" maskBorderWidth
+|> add "mask-clip" maskClip
+|> add "mask-composite" maskComposite
+|> add "mask-image" maskImage
+|> add "mask-mode" maskMode
+|> add "mask-origin" maskOrigin
+|> add "mask-position" maskPosition
+|> add "mask-repeat" maskRepeat
+|> add "mask-size" maskSize
+|> add "mask-type" maskType
+|> add "background-blend-mode" backgroundBlendMode
+|> add "isolation" isolation
+|> add "mix-blend-mode" mixBlendMode
+|> add "box-decoration-break" boxDecorationBreak
+|> add "box-sizing" boxSizing
+|> add "caret-color" caretColor
+|> add "nav-down" navDown
+|> add "nav-left" navLeft
+|> add "nav-right" navRight
+|> add "nav-up" navUp
+|> add "outline-offset" outlineOffset
+|> add "resize" resize
+|> add "text-overflow" textOverflow
+|> add "grid" grid
+|> add "grid-area" gridArea
+|> add "grid-auto-columns" gridAutoColumns
+|> add "grid-auto-flow" gridAutoFlow
+|> add "grid-auto-rows" gridAutoRows
+|> add "grid-column" gridColumn
+|> add "grid-column-end" gridColumnEnd
+|> add "grid-column-gap" gridColumnGap
+|> add "grid-column-start" gridColumnStart
+|> add "grid-gap" gridGap
+|> add "grid-row" gridRow
+|> add "grid-row-end" gridRowEnd
+|> add "grid-row-gap" gridRowGap
+|> add "grid-row-start" gridRowStart
+|> add "grid-template" gridTemplate
+|> add "grid-template-areas" gridTemplateAreas
+|> add "grid-template-columns" gridTemplateColumns
+|> add "grid-template-rows" gridTemplateRows
+|> add "will-change" willChange
+|> add "hanging-punctuation" hangingPunctuation
+|> add "hyphens" hyphens
+|> add "line-break" lineBreak
+|> add "overflow-wrap" overflowWrap
+|> add "tab-size" tabSize
+|> add "text-align-last" textAlignLast
+|> add "text-justify" textJustify
+|> add "word-break" wordBreak
+|> add "word-wrap" wordWrap
+|> add "animation" animation
+|> add "animation-delay" animationDelay
+|> add "animation-direction" animationDirection
+|> add "animation-duration" animationDuration
+|> add "animation-fill-mode" animationFillMode
+|> add "animation-iteration-count" animationIterationCount
+|> add "animation-name" animationName
+|> add "animation-play-state" animationPlayState
+|> add "animation-timing-function" animationTimingFunction
+|> add "transition" transition
+|> add "transition-delay" transitionDelay
+|> add "transition-duration" transitionDuration
+|> add "transition-property" transitionProperty
+|> add "transition-timing-function" transitionTimingFunction
+|> add "backface-visibility" backfaceVisibility
+|> add "perspective" perspective
+|> add "perspective-origin" perspectiveOrigin
+|> add "transform" transform
+|> add "transform-origin" transformOrigin
+|> add "transform-style" transformStyle
+|> add "justify-items" justifyItems
+|> add "justify-self" justifySelf
+|> add "place-content" placeContent
+|> add "place-items" placeItems
+|> add "place-self" placeSelf
+|> add "appearance" appearance
+|> add "caret" caret
+|> add "caret-animation" caretAnimation
+|> add "caret-shape" caretShape
+|> add "user-select" userSelect
+|> add "max-lines" maxLines
+|> add "marquee-direction" marqueeDirection
+|> add "marquee-loop" marqueeLoop
+|> add "marquee-speed" marqueeSpeed
+|> add "marquee-style" marqueeStyle
+|> add "overflow-style" overflowStyle
+|> add "rotation" rotation
+|> add "rotation-point" rotationPoint
+|> add "alignment-baseline" alignmentBaseline
+|> add "baseline-shift" baselineShift
+|> add "clip" clip
+|> add "clip-path" clipPath
+|> add "clip-rule" clipRule
+|> add "color-interpolation" colorInterpolation
+|> add "color-interpolation-filters" colorInterpolationFilters
+|> add "color-profile" colorProfile
+|> add "color-rendering" colorRendering
+|> add "cursor" cursor
+|> add "dominant-baseline" dominantBaseline
+|> add "fill" fill
+|> add "fill-opacity" fillOpacity
+|> add "fill-rule" fillRule
+|> add "filter" filter
+|> add "flood-color" floodColor
+|> add "flood-opacity" floodOpacity
+|> add "glyph-orientation-horizontal" glyphOrientationHorizontal
+|> add "glyph-orientation-vertical" glyphOrientationVertical
+|> add "image-rendering" imageRendering
+|> add "kerning" kerning
+|> add "lighting-color" lightingColor
+|> add "marker-end" markerEnd
+|> add "marker-mid" markerMid
+|> add "marker-start" markerStart
+|> add "pointer-events" pointerEvents
+|> add "shape-rendering" shapeRendering
+|> add "stop-color" stopColor
+|> add "stop-opacity" stopOpacity
+|> add "stroke" stroke
+|> add "stroke-dasharray" strokeDasharray
+|> add "stroke-dashoffset" strokeDashoffset
+|> add "stroke-linecap" strokeLinecap
+|> add "stroke-linejoin" strokeLinejoin
+|> add "stroke-miterlimit" strokeMiterlimit
+|> add "stroke-opacity" strokeOpacity
+|> add "stroke-width" strokeWidth
+|> add "text-anchor" textAnchor
+|> add "text-rendering" textRendering
+|> add "ruby-align" rubyAlign
+|> add "ruby-merge" rubyMerge
+|> add "ruby-position" rubyPosition
 [@@@ocamlformat "enable"]
 
 let to_string (styles : t) : string =
   let size = List.length styles in
   let buff = Buffer.create size in
-  List.to_seq styles
+  List.rev styles |> List.to_seq
   |> Seq.iteri (fun index (k, v) ->
          if index == size - 1 then (
            Buffer.add_string buff k;
-           Buffer.add_string buff ": ";
+           Buffer.add_string buff ":";
            Buffer.add_string buff (String.trim v))
          else (
            Buffer.add_string buff k;
-           Buffer.add_string buff ": ";
+           Buffer.add_string buff ":";
            Buffer.add_string buff (String.trim v);
-           Buffer.add_string buff "; "));
+           Buffer.add_string buff ";"));
   Buffer.contents buff
 
 let combine (styles1 : t) (styles2 : t) : t =
@@ -736,7 +742,7 @@ let camelcaseToKebabcase str =
 
 let unsafeAddProp styles (key : string) (value : string) : t =
   (* Adds the (key,value) into last position *)
-  styles @ [ (camelcaseToKebabcase key, value) ]
+  (camelcaseToKebabcase key, value) :: styles
 
 (* Since we don't have a proper representation of `< .. > Js.t` yet,
    we can't make the unsafeAddStyle

--- a/packages/reactDom/test/test_reactDOMStyle.ml
+++ b/packages/reactDom/test/test_reactDOMStyle.ml
@@ -4,11 +4,11 @@ let assert_styles styles str =
 
 let two_styles () =
   let styles = ReactDOM.Style.make ~background:"#333" ~fontSize:"24px" () in
-  assert_styles styles "background: #333; font-size: 24px"
+  assert_styles styles "background:#333;font-size:24px"
 
 let one_styles () =
   let styles = ReactDOM.Style.make ~background:"#333" () in
-  assert_styles styles "background: #333"
+  assert_styles styles "background:#333"
 
 let zero_styles () =
   let styles = ReactDOM.Style.make () in
@@ -20,13 +20,13 @@ let unsafe_add_prop () =
       (ReactDOM.Style.make ~background:"#333" ())
       "colorScheme" "dark"
   in
-  assert_styles styles "background: #333; color-scheme: dark"
+  assert_styles styles "background:#333;color-scheme:dark"
 
 let style_order_matters () =
   let styles =
     ReactDOM.Style.make ~lineBreak:"100px" ~overflowWrap:"break-word" ()
   in
-  assert_styles styles "line-break: 100px; overflow-wrap: break-word"
+  assert_styles styles "line-break:100px;overflow-wrap:break-word"
 
 let case title fn = Alcotest_lwt.test_case_sync title `Quick fn
 

--- a/packages/server-reason-react-ppx/test/test.re
+++ b/packages/server-reason-react-ppx/test/test.re
@@ -269,7 +269,7 @@ let create_element_variadic = () => {
   let component = <Text tagType=Text.Tag.H1> {React.string("Hello")} </Text>;
   assert_string(
     ReactDOM.renderToStaticMarkup(component),
-    "<h1 style=\"display: none\" class=\"foo\">Hello</h1>",
+    "<h1 style=\"display:none\" class=\"foo\">Hello</h1>",
   );
 };
 

--- a/packages/server-reason-react-ppx/test/test.re
+++ b/packages/server-reason-react-ppx/test/test.re
@@ -47,7 +47,7 @@ let style_attribute = () => {
     <div style={ReactDOM.Style.make(~backgroundColor="gainsboro", ())} />;
   assert_string(
     ReactDOM.renderToStaticMarkup(div),
-    "<div style=\"background-color: gainsboro\"></div>",
+    "<div style=\"background-color:gainsboro\"></div>",
   );
 };
 
@@ -156,7 +156,7 @@ let style_opt_attribute_some = () => {
   let div = <div ?style />;
   assert_string(
     ReactDOM.renderToStaticMarkup(div),
-    "<div style=\"background-color: gainsboro\"></div>",
+    "<div style=\"background-color:gainsboro\"></div>",
   );
 };
 


### PR DESCRIPTION
This reorders the styles to match the order used by reason-react, in order to silence React warnings about inline styles on the client not matching the server's values.

The list was generated from the reason-react repo with the following script:

```sh
for style in $(cat src/dOMStyle.re | grep "~" | sed 's/.*\~\([^:]*\):.*/\1/'); do
  dashed=$(echo "$style" | sed 's/\([A-Z]\)/-\L\1/g')
  echo "|> add \"$dashed\" $style"
done
```