### PR TITLE
silence unused-value-declaration warning in browser_only ppx

### DIFF
--- a/packages/ppx/browser.ml
+++ b/packages/ppx/browser.ml
@@ -42,8 +42,8 @@ module Browser_only = struct
       match expr.pexp_desc with
       | Pexp_fun (_arg_label, _arg_expression, pattern, expr) ->
           [%expr
-            fun [%p pattern] ->
-              ([%e last_expr_to_raise_impossbile name expr] [@warning "-27"])]
+            fun [@warning "-27"] [%p pattern] ->
+              [%e last_expr_to_raise_impossbile name expr]]
       | _ ->
           let message = Builder.estring ~loc name in
           [%expr raise (ReactDOM.Impossible_in_ssr [%e message])]
@@ -60,7 +60,7 @@ module Browser_only = struct
             let vb = Builder.value_binding ~loc ~pat:pattern ~expr in
             let warning27 =
               Builder.attribute ~loc ~name:{ txt = "warning"; loc }
-                ~payload:(PStr [ [%stri "-27"] ])
+                ~payload:(PStr [ [%stri "-27-26"] ])
             in
             { vb with pvb_attributes = [ warning27 ] }
         | _ ->
@@ -89,9 +89,8 @@ module Browser_only = struct
               let stringified = Ppxlib.Pprintast.string_of_expression payload in
               let message = Builder.estring ~loc stringified in
               [%expr
-                fun [%p fun_pattern] ->
-                  raise
-                    (ReactDOM.Impossible_in_ssr [%e message] [@warning "-27"])]
+                fun [@warning "-27"] [%p fun_pattern] ->
+                  raise (ReactDOM.Impossible_in_ssr [%e message])]
           | Pexp_let (rec_flag, value_bindings, expression) ->
               let pexp_let =
                 Builder.pexp_let ~loc rec_flag

--- a/packages/ppx/browser.ml
+++ b/packages/ppx/browser.ml
@@ -147,7 +147,7 @@ module Browser_only = struct
                 let [%p pattern] =
                  fun [%p fun_pattern] ->
                   [%e last_expr_to_raise_impossbile message expr]
-                [@@warning "-27"]]
+                [@@warning "-27-32"]]
           | _expr -> do_nothing rec_flag)
     in
     Context_free.Rule.extension

--- a/packages/ppx/tests/browser_only.t/run.t
+++ b/packages/ppx/tests/browser_only.t/run.t
@@ -34,29 +34,32 @@ Without -js flag, the compilation to native replaces the expression with `raise 
   let valueFromEvent evt =
     raise
       (ReactDOM.Impossible_in_ssr "fun evt -> Webapi.Dom.getElementById \"foo\"")
-  [@@warning "-27"]
+  [@@warning "-27-32"]
   
   let valueFromEvent evt moar_arguments =
     raise
       (ReactDOM.Impossible_in_ssr
          "fun evt -> fun moar_arguments -> Webapi.Dom.getElementById \"foo\"")
-  [@@warning "-27"]
+  [@@warning "-27-32"]
   
   let make () =
     let _ = raise (ReactDOM.Impossible_in_ssr "Webapi.Dom.getElementById") in
     let valueFromEvent =
       [%ocaml.error "browser only works on expressions or function definitions"]
     in
-    let valueFromEvent evt =
+    let valueFromEvent =
+     fun [@warning "-27"] evt ->
       raise
         (ReactDOM.Impossible_in_ssr "fun evt -> Webapi.Dom.getElementById \"foo\"")
-        [@@warning "-27"]
+       [@@warning "-27-26"]
     in
-    let valueFromEvent evt moar_arguments =
-      raise
-        (ReactDOM.Impossible_in_ssr
-           "fun evt -> fun moar_arguments -> Webapi.Dom.getElementById \"foo\"")
-        [@@warning "-27"]
+    let valueFromEvent =
+     fun [@warning "-27"] evt ->
+      fun [@warning "-27"] moar_arguments ->
+       raise
+         (ReactDOM.Impossible_in_ssr
+            "fun evt -> fun moar_arguments -> Webapi.Dom.getElementById \"foo\"")
+       [@@warning "-27-26"]
     in
     React.createElement "div"
   
@@ -64,35 +67,39 @@ Without -js flag, the compilation to native replaces the expression with `raise 
   
   let loadInitialText () =
     raise (ReactDOM.Impossible_in_ssr "fun () -> setHtmlFetchState Loading")
-  [@@warning "-27"]
+  [@@warning "-27-32"]
   
   let loadInitialText argument1 =
     raise
       (ReactDOM.Impossible_in_ssr "fun argument1 -> setHtmlFetchState Loading")
-  [@@warning "-27"]
+  [@@warning "-27-32"]
   
   let loadInitialText argument1 argument2 =
     raise
       (ReactDOM.Impossible_in_ssr
          "fun argument1 -> fun argument2 -> setHtmlFetchState Loading")
-  [@@warning "-27"]
+  [@@warning "-27-32"]
   
   let make () =
     let _ = raise (ReactDOM.Impossible_in_ssr "Webapi.Dom.getElementById") in
-    let loadInitialText () =
+    let loadInitialText =
+     fun [@warning "-27"] () ->
       raise (ReactDOM.Impossible_in_ssr "fun () -> setHtmlFetchState Loading")
-        [@@warning "-27"]
+       [@@warning "-27-26"]
     in
-    let loadInitialText argument1 =
+    let loadInitialText =
+     fun [@warning "-27"] argument1 ->
       raise
         (ReactDOM.Impossible_in_ssr "fun argument1 -> setHtmlFetchState Loading")
-        [@@warning "-27"]
+       [@@warning "-27-26"]
     in
-    let loadInitialText argument1 argument2 =
-      raise
-        (ReactDOM.Impossible_in_ssr
-           "fun argument1 -> fun argument2 -> setHtmlFetchState Loading")
-        [@@warning "-27"]
+    let loadInitialText =
+     fun [@warning "-27"] argument1 ->
+      fun [@warning "-27"] argument2 ->
+       raise
+         (ReactDOM.Impossible_in_ssr
+            "fun argument1 -> fun argument2 -> setHtmlFetchState Loading")
+       [@@warning "-27-26"]
     in
     React.createElement "div"
 
@@ -104,29 +111,32 @@ Without -js flag, the compilation to native replaces the expression with `raise 
   let valueFromEvent evt =
     raise
       (ReactDOM.Impossible_in_ssr "fun evt -> Webapi.Dom.getElementById \"foo\"")
-  [@@warning "-27"]
+  [@@warning "-27-32"]
   
   let valueFromEvent evt moar_arguments =
     raise
       (ReactDOM.Impossible_in_ssr
          "fun evt -> fun moar_arguments -> Webapi.Dom.getElementById \"foo\"")
-  [@@warning "-27"]
+  [@@warning "-27-32"]
   
   let make () =
     let _ = raise (ReactDOM.Impossible_in_ssr "Webapi.Dom.getElementById") in
     let valueFromEvent =
       [%ocaml.error "browser only works on expressions or function definitions"]
     in
-    let valueFromEvent evt =
+    let valueFromEvent =
+     fun [@warning "-27"] evt ->
       raise
         (ReactDOM.Impossible_in_ssr "fun evt -> Webapi.Dom.getElementById \"foo\"")
-        [@@warning "-27"]
+       [@@warning "-27-26"]
     in
-    let valueFromEvent evt moar_arguments =
-      raise
-        (ReactDOM.Impossible_in_ssr
-           "fun evt -> fun moar_arguments -> Webapi.Dom.getElementById \"foo\"")
-        [@@warning "-27"]
+    let valueFromEvent =
+     fun [@warning "-27"] evt ->
+      fun [@warning "-27"] moar_arguments ->
+       raise
+         (ReactDOM.Impossible_in_ssr
+            "fun evt -> fun moar_arguments -> Webapi.Dom.getElementById \"foo\"")
+       [@@warning "-27-26"]
     in
     React.createElement "div"
   
@@ -134,34 +144,38 @@ Without -js flag, the compilation to native replaces the expression with `raise 
   
   let loadInitialText () =
     raise (ReactDOM.Impossible_in_ssr "fun () -> setHtmlFetchState Loading")
-  [@@warning "-27"]
+  [@@warning "-27-32"]
   
   let loadInitialText argument1 =
     raise
       (ReactDOM.Impossible_in_ssr "fun argument1 -> setHtmlFetchState Loading")
-  [@@warning "-27"]
+  [@@warning "-27-32"]
   
   let loadInitialText argument1 argument2 =
     raise
       (ReactDOM.Impossible_in_ssr
          "fun argument1 -> fun argument2 -> setHtmlFetchState Loading")
-  [@@warning "-27"]
+  [@@warning "-27-32"]
   
   let make () =
     let _ = raise (ReactDOM.Impossible_in_ssr "Webapi.Dom.getElementById") in
-    let loadInitialText () =
+    let loadInitialText =
+     fun [@warning "-27"] () ->
       raise (ReactDOM.Impossible_in_ssr "fun () -> setHtmlFetchState Loading")
-        [@@warning "-27"]
+       [@@warning "-27-26"]
     in
-    let loadInitialText argument1 =
+    let loadInitialText =
+     fun [@warning "-27"] argument1 ->
       raise
         (ReactDOM.Impossible_in_ssr "fun argument1 -> setHtmlFetchState Loading")
-        [@@warning "-27"]
+       [@@warning "-27-26"]
     in
-    let loadInitialText argument1 argument2 =
-      raise
-        (ReactDOM.Impossible_in_ssr
-           "fun argument1 -> fun argument2 -> setHtmlFetchState Loading")
-        [@@warning "-27"]
+    let loadInitialText =
+     fun [@warning "-27"] argument1 ->
+      fun [@warning "-27"] argument2 ->
+       raise
+         (ReactDOM.Impossible_in_ssr
+            "fun argument1 -> fun argument2 -> setHtmlFetchState Loading")
+       [@@warning "-27-26"]
     in
     React.createElement "div"


### PR DESCRIPTION
This silences the warnings you get when a `browser_only` definition is unused from the native perspective, common when it is only called from expressions that are themselves marked as `browser_only`.