### PR TITLE
Improve browser_only logging

### DIFF
--- a/packages/ppx/browser.ml
+++ b/packages/ppx/browser.ml
@@ -36,8 +36,19 @@ module Effect = struct
 end
 
 module Browser_only = struct
+  let get_function_name pattern =
+    match pattern with Ppat_var { txt = name; _ } -> name | _ -> "unkwnown"
+
+  let error_only_works_on ~loc =
+    [%expr
+      [%ocaml.error
+        "browser_only works on function definitions. If there's another case \
+         where it can be helpful, feel free to open an issue in \
+         https://github.com/ml-in-barcelona/server-reason-react."]]
+
   let browser_only_value_binding pattern expression =
     let loc = pattern.ppat_loc in
+    let original_function_name = get_function_name pattern.ppat_desc in
     let rec last_expr_to_raise_impossbile name expr =
       match expr.pexp_desc with
       | Pexp_fun (arg_label, arg_expression, pattern, expr) ->
@@ -56,18 +67,17 @@ module Browser_only = struct
               remove_unused_variable_warning27 ~loc :: expr.pexp_attributes;
           }
       | _ ->
-          let message = Builder.estring ~loc name in
-          [%expr raise (ReactDOM.Impossible_in_ssr [%e message])]
+          let message = Builder.estring ~loc original_function_name in
+          [%expr Runtime.fail_impossible_action_in_ssr [%e message]]
     in
     match pattern with
     | [%pat? ()] -> Builder.value_binding ~loc ~pat:pattern ~expr:[%expr ()]
     | _ -> (
         match expression.pexp_desc with
         | Pexp_fun (_arg_label, _arg_expression, _fun_pattern, _expr) ->
-            let stringified =
-              Ppxlib.Pprintast.string_of_expression expression
+            let expr =
+              last_expr_to_raise_impossbile original_function_name expression
             in
-            let expr = last_expr_to_raise_impossbile stringified expression in
             let vb = Builder.value_binding ~loc ~pat:pattern ~expr in
             let remove_unused_variable_warning27 =
               Builder.attribute ~loc ~name:{ txt = "warning"; loc }
@@ -76,11 +86,15 @@ module Browser_only = struct
             { vb with pvb_attributes = [ remove_unused_variable_warning27 ] }
         | _ ->
             Builder.value_binding ~loc ~pat:pattern
-              ~expr:
-                [%expr
-                  [%ocaml.error
-                    "browser only works on expressions or function definitions"]]
-        )
+              ~expr:(error_only_works_on ~loc))
+
+  let get_function_name_from_payload expression =
+    match expression with
+    | { pexp_desc = Pexp_apply (expression, _); _ } -> (
+        match expression.pexp_desc with
+        | Pexp_ident { txt = Ldot (Lident _, name); _ } -> name
+        | _ -> "unknown")
+    | _ -> "unknown"
 
   let expression_rule =
     let extractor = Ast_pattern.(single_expr_payload __) in
@@ -95,18 +109,20 @@ module Browser_only = struct
                 Ppxlib.Pprintast.string_of_expression expression
               in
               let message = Builder.estring ~loc stringified in
-              [%expr raise (ReactDOM.Impossible_in_ssr [%e message])]
-          | Pexp_fun (arg_label, arg_expression, pattern, expr) ->
-              let stringified = Ppxlib.Pprintast.string_of_expression payload in
+              [%expr Runtime.fail_impossible_action_in_ssr [%e message]]
+          | Pexp_fun (arg_label, arg_expression, pattern, expression) ->
+              let stringified =
+                Ppxlib.Pprintast.string_of_expression expression
+              in
               let message = Builder.estring ~loc stringified in
               let fn =
                 Builder.pexp_fun ~loc arg_label arg_expression pattern
-                  [%expr raise (ReactDOM.Impossible_in_ssr [%e message])]
+                  [%expr Runtime.fail_impossible_action_in_ssr [%e message]]
               in
               {
                 fn with
                 pexp_attributes =
-                  expr.pexp_attributes
+                  expression.pexp_attributes
                   @ [
                       Builder.attribute ~loc ~name:{ txt = "warning"; loc }
                         ~payload:(PStr [ [%stri "-27"] ]);
@@ -123,10 +139,7 @@ module Browser_only = struct
                   expression
               in
               [%expr [%e pexp_let] [@warning "-27"]]
-          | _ ->
-              [%expr
-                [%ocaml.error
-                  "browser only works on expressions or function definitions"]])
+          | _ -> error_only_works_on ~loc)
     in
     Context_free.Rule.extension
       (Extension.V3.declare "browser_only" Extension.Context.expression
@@ -147,17 +160,18 @@ module Browser_only = struct
         | Recursive -> [%stri let rec [%p pattern] = [%e expression]]
         | Nonrecursive -> [%stri let [%p pattern] = [%e expression]]
       in
-      let rec last_expr_to_raise_impossbile name expr =
+      let rec last_expr_to_raise_impossbile original_name expr =
         match expr.pexp_desc with
         | Pexp_fun (arg_label, arg_expression, pattern, expression) ->
             let fn =
               Builder.pexp_fun ~loc arg_label arg_expression pattern
-                (last_expr_to_raise_impossbile name expression)
+                (last_expr_to_raise_impossbile original_name expression)
             in
             { fn with pexp_attributes = expr.pexp_attributes }
         | _ ->
-            let message = Builder.estring ~loc name in
-            [%expr raise (ReactDOM.Impossible_in_ssr [%e message])]
+            [%expr
+              Runtime.fail_impossible_action_in_ssr
+                [%e Builder.estring ~loc original_name]]
       in
       match !mode with
       (* When it's Js, keep item as it is *)
@@ -165,10 +179,12 @@ module Browser_only = struct
       | Native -> (
           match expression.pexp_desc with
           | Pexp_fun (arg_label, arg_expression, fun_pattern, expr) ->
-              let name = Ppxlib.Pprintast.string_of_expression expression in
+              let original_function_name =
+                get_function_name fun_pattern.ppat_desc
+              in
               let fn =
                 Builder.pexp_fun ~loc arg_label arg_expression fun_pattern
-                  (last_expr_to_raise_impossbile name expr)
+                  (last_expr_to_raise_impossbile original_function_name expr)
               in
               let item = { fn with pexp_attributes = expr.pexp_attributes } in
               [%stri let [%p pattern] = [%e item] [@@warning "-27-32"]]

--- a/packages/ppx/dune
+++ b/packages/ppx/dune
@@ -30,6 +30,7 @@
  (public_name server-reason-react.browser_ppx)
  (flags :standard -w -9)
  (libraries ppxlib ppxlib.astlib)
+ (ppx_runtime_libraries server-reason-react.runtime)
  (preprocess
   (pps ppxlib.metaquot))
  (kind ppx_rewriter))

--- a/packages/ppx/tests/browser_only.t/input.ml
+++ b/packages/ppx/tests/browser_only.t/input.ml
@@ -1,39 +1,27 @@
-let _ = [%browser_only Webapi.Dom.getElementById "foo"]
-let%browser_only valueFromEvent = Webapi.Dom.getElementById "foo"
-let%browser_only valueFromEvent evt = Webapi.Dom.getElementById "foo"
+let pstr_value_binding = [%browser_only Webapi.Dom.getElementById "foo"]
+let%browser_only pstr_value_binding_2 = Webapi.Dom.getElementById "foo"
 
-let%browser_only valueFromEvent evt moar_arguments =
+let%browser_only pexp_fun_1arg_structure_item evt =
+  Webapi.Dom.getElementById "foo"
+
+let%browser_only pexp_fun_2arg_structure_item evt moar_arguments =
   Webapi.Dom.getElementById "foo"
 
 let make () =
-  let _ = [%browser_only Webapi.Dom.getElementById "foo"] in
-  let%browser_only valueFromEvent = Webapi.Dom.getElementById "foo" in
-  let%browser_only valueFromEvent evt = Webapi.Dom.getElementById "foo" in
-
-  let%browser_only valueFromEvent evt moar_arguments =
+  let fun_value_binding_pexp =
+    [%browser_only Webapi.Dom.getElementById "foo"]
+  in
+  let%browser_only fun_value_binding_pexp_2 = Webapi.Dom.getElementById "foo" in
+  let%browser_only fun_value_binding_pexp_fun_1arg evt =
     Webapi.Dom.getElementById "foo"
   in
 
-  React.createElement "div"
-
-let _ = [%browser_only Webapi.Dom.getElementById "foo"]
-let%browser_only loadInitialText () = setHtmlFetchState Loading
-let%browser_only loadInitialText argument1 = setHtmlFetchState Loading
-let%browser_only loadInitialText argument1 argument2 = setHtmlFetchState Loading
-let%browser_only labeled ~argument1 ~argument2 = setHtmlFetchState Loading
-let getById = [%browser_only fun id -> Webapi.Dom.getElementById id]
-
-let make () =
-  let _ = [%browser_only Webapi.Dom.getElementById "foo"] in
-
-  let%browser_only loadInitialText () = setHtmlFetchState Loading in
-
-  let%browser_only loadInitialText argument1 = setHtmlFetchState Loading in
-
-  let%browser_only loadInitialText argument1 argument2 =
-    setHtmlFetchState Loading
+  let%browser_only fun_value_binding_pexp_fun_2arg evt moar_arguments =
+    Webapi.Dom.getElementById "foo"
   in
 
-  let%browser_only labeled ~argument1 ~argument2 = setHtmlFetchState Loading in
+  let%browser_only fun_value_binding_labelled_args ~argument1 ~argument2 =
+    setHtmlFetchState Loading
+  in
 
   React.createElement "div"

--- a/packages/ppx/tests/browser_only.t/run.t
+++ b/packages/ppx/tests/browser_only.t/run.t
@@ -31,190 +31,160 @@ With -js flag everything keeps as it is and browser_only extension disappears
 Without -js flag, the compilation to native replaces the expression with `raise (ReactDOM.Impossible_in_ssr`
 
   $ ../standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl
-  let _ = raise (ReactDOM.Impossible_in_ssr "Webapi.Dom.getElementById")
+  let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById"
   let valueFromEvent = Webapi.Dom.getElementById "foo"
   
-  let valueFromEvent evt =
-    raise
-      (ReactDOM.Impossible_in_ssr "fun evt -> Webapi.Dom.getElementById \"foo\"")
+  let valueFromEvent evt = Runtime.fail_impossible_action_in_ssr "evt"
   [@@warning "-27-32"]
   
   let valueFromEvent evt moar_arguments =
-    raise
-      (ReactDOM.Impossible_in_ssr
-         "fun evt -> fun moar_arguments -> Webapi.Dom.getElementById \"foo\"")
+    Runtime.fail_impossible_action_in_ssr "evt"
   [@@warning "-27-32"]
   
   let make () =
-    let _ = raise (ReactDOM.Impossible_in_ssr "Webapi.Dom.getElementById") in
+    let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById" in
     let valueFromEvent =
-      [%ocaml.error "browser only works on expressions or function definitions"]
+      [%ocaml.error
+        "browser_only works on function definitions. If there's another case \
+         where it can be helpful, feel free to open an issue in \
+         https://github.com/ml-in-barcelona/server-reason-react."]
     in
     let valueFromEvent =
      fun [@warning "-27"] evt ->
-      raise
-        (ReactDOM.Impossible_in_ssr "fun evt -> Webapi.Dom.getElementById \"foo\"")
+      Runtime.fail_impossible_action_in_ssr "valueFromEvent"
        [@@warning "-27-26"]
     in
     let valueFromEvent =
      fun [@warning "-27"] evt ->
       fun [@warning "-27"] moar_arguments ->
-       raise
-         (ReactDOM.Impossible_in_ssr
-            "fun evt -> fun moar_arguments -> Webapi.Dom.getElementById \"foo\"")
+       Runtime.fail_impossible_action_in_ssr "valueFromEvent"
        [@@warning "-27-26"]
     in
     React.createElement "div"
   
-  let _ = raise (ReactDOM.Impossible_in_ssr "Webapi.Dom.getElementById")
+  let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById"
   
-  let loadInitialText () =
-    raise (ReactDOM.Impossible_in_ssr "fun () -> setHtmlFetchState Loading")
+  let loadInitialText () = Runtime.fail_impossible_action_in_ssr "unkwnown"
   [@@warning "-27-32"]
   
   let loadInitialText argument1 =
-    raise
-      (ReactDOM.Impossible_in_ssr "fun argument1 -> setHtmlFetchState Loading")
+    Runtime.fail_impossible_action_in_ssr "argument1"
   [@@warning "-27-32"]
   
   let loadInitialText argument1 argument2 =
-    raise
-      (ReactDOM.Impossible_in_ssr
-         "fun argument1 -> fun argument2 -> setHtmlFetchState Loading")
+    Runtime.fail_impossible_action_in_ssr "argument1"
   [@@warning "-27-32"]
   
   let labeled ~argument1 ~argument2 =
-    raise
-      (ReactDOM.Impossible_in_ssr
-         "fun ~argument1 -> fun ~argument2 -> setHtmlFetchState Loading")
+    Runtime.fail_impossible_action_in_ssr "argument1"
   [@@warning "-27-32"]
   
   let getById =
    fun [@warning "-27"] id ->
-    raise (ReactDOM.Impossible_in_ssr "fun id -> Webapi.Dom.getElementById id")
+    Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById id"
   
   let make () =
-    let _ = raise (ReactDOM.Impossible_in_ssr "Webapi.Dom.getElementById") in
+    let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById" in
     let loadInitialText =
      fun [@warning "-27"] () ->
-      raise (ReactDOM.Impossible_in_ssr "fun () -> setHtmlFetchState Loading")
+      Runtime.fail_impossible_action_in_ssr "loadInitialText"
        [@@warning "-27-26"]
     in
     let loadInitialText =
      fun [@warning "-27"] argument1 ->
-      raise
-        (ReactDOM.Impossible_in_ssr "fun argument1 -> setHtmlFetchState Loading")
+      Runtime.fail_impossible_action_in_ssr "loadInitialText"
        [@@warning "-27-26"]
     in
     let loadInitialText =
      fun [@warning "-27"] argument1 ->
       fun [@warning "-27"] argument2 ->
-       raise
-         (ReactDOM.Impossible_in_ssr
-            "fun argument1 -> fun argument2 -> setHtmlFetchState Loading")
+       Runtime.fail_impossible_action_in_ssr "loadInitialText"
        [@@warning "-27-26"]
     in
     let labeled =
      fun [@warning "-27"] ~argument1 ->
       fun [@warning "-27"] ~argument2 ->
-       raise
-         (ReactDOM.Impossible_in_ssr
-            "fun ~argument1 -> fun ~argument2 -> setHtmlFetchState Loading")
+       Runtime.fail_impossible_action_in_ssr "labeled"
        [@@warning "-27-26"]
     in
     React.createElement "div"
 
 
   $ ../standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl
-  let _ = raise (ReactDOM.Impossible_in_ssr "Webapi.Dom.getElementById")
+  let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById"
   let valueFromEvent = Webapi.Dom.getElementById "foo"
   
-  let valueFromEvent evt =
-    raise
-      (ReactDOM.Impossible_in_ssr "fun evt -> Webapi.Dom.getElementById \"foo\"")
+  let valueFromEvent evt = Runtime.fail_impossible_action_in_ssr "evt"
   [@@warning "-27-32"]
   
   let valueFromEvent evt moar_arguments =
-    raise
-      (ReactDOM.Impossible_in_ssr
-         "fun evt -> fun moar_arguments -> Webapi.Dom.getElementById \"foo\"")
+    Runtime.fail_impossible_action_in_ssr "evt"
   [@@warning "-27-32"]
   
   let make () =
-    let _ = raise (ReactDOM.Impossible_in_ssr "Webapi.Dom.getElementById") in
+    let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById" in
     let valueFromEvent =
-      [%ocaml.error "browser only works on expressions or function definitions"]
+      [%ocaml.error
+        "browser_only works on function definitions. If there's another case \
+         where it can be helpful, feel free to open an issue in \
+         https://github.com/ml-in-barcelona/server-reason-react."]
     in
     let valueFromEvent =
      fun [@warning "-27"] evt ->
-      raise
-        (ReactDOM.Impossible_in_ssr "fun evt -> Webapi.Dom.getElementById \"foo\"")
+      Runtime.fail_impossible_action_in_ssr "valueFromEvent"
        [@@warning "-27-26"]
     in
     let valueFromEvent =
      fun [@warning "-27"] evt ->
       fun [@warning "-27"] moar_arguments ->
-       raise
-         (ReactDOM.Impossible_in_ssr
-            "fun evt -> fun moar_arguments -> Webapi.Dom.getElementById \"foo\"")
+       Runtime.fail_impossible_action_in_ssr "valueFromEvent"
        [@@warning "-27-26"]
     in
     React.createElement "div"
   
-  let _ = raise (ReactDOM.Impossible_in_ssr "Webapi.Dom.getElementById")
+  let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById"
   
-  let loadInitialText () =
-    raise (ReactDOM.Impossible_in_ssr "fun () -> setHtmlFetchState Loading")
+  let loadInitialText () = Runtime.fail_impossible_action_in_ssr "unkwnown"
   [@@warning "-27-32"]
   
   let loadInitialText argument1 =
-    raise
-      (ReactDOM.Impossible_in_ssr "fun argument1 -> setHtmlFetchState Loading")
+    Runtime.fail_impossible_action_in_ssr "argument1"
   [@@warning "-27-32"]
   
   let loadInitialText argument1 argument2 =
-    raise
-      (ReactDOM.Impossible_in_ssr
-         "fun argument1 -> fun argument2 -> setHtmlFetchState Loading")
+    Runtime.fail_impossible_action_in_ssr "argument1"
   [@@warning "-27-32"]
   
   let labeled ~argument1 ~argument2 =
-    raise
-      (ReactDOM.Impossible_in_ssr
-         "fun ~argument1 -> fun ~argument2 -> setHtmlFetchState Loading")
+    Runtime.fail_impossible_action_in_ssr "argument1"
   [@@warning "-27-32"]
   
   let getById =
    fun [@warning "-27"] id ->
-    raise (ReactDOM.Impossible_in_ssr "fun id -> Webapi.Dom.getElementById id")
+    Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById id"
   
   let make () =
-    let _ = raise (ReactDOM.Impossible_in_ssr "Webapi.Dom.getElementById") in
+    let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById" in
     let loadInitialText =
      fun [@warning "-27"] () ->
-      raise (ReactDOM.Impossible_in_ssr "fun () -> setHtmlFetchState Loading")
+      Runtime.fail_impossible_action_in_ssr "loadInitialText"
        [@@warning "-27-26"]
     in
     let loadInitialText =
      fun [@warning "-27"] argument1 ->
-      raise
-        (ReactDOM.Impossible_in_ssr "fun argument1 -> setHtmlFetchState Loading")
+      Runtime.fail_impossible_action_in_ssr "loadInitialText"
        [@@warning "-27-26"]
     in
     let loadInitialText =
      fun [@warning "-27"] argument1 ->
       fun [@warning "-27"] argument2 ->
-       raise
-         (ReactDOM.Impossible_in_ssr
-            "fun argument1 -> fun argument2 -> setHtmlFetchState Loading")
+       Runtime.fail_impossible_action_in_ssr "loadInitialText"
        [@@warning "-27-26"]
     in
     let labeled =
      fun [@warning "-27"] ~argument1 ->
       fun [@warning "-27"] ~argument2 ->
-       raise
-         (ReactDOM.Impossible_in_ssr
-            "fun ~argument1 -> fun ~argument2 -> setHtmlFetchState Loading")
+       Runtime.fail_impossible_action_in_ssr "labeled"
        [@@warning "-27-26"]
     in
     React.createElement "div"

--- a/packages/ppx/tests/browser_only.t/run.t
+++ b/packages/ppx/tests/browser_only.t/run.t
@@ -40,27 +40,31 @@ Without -js flag, the compilation to native replaces the expression with `raise 
     let fun_value_binding_pexp =
       Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById"
     in
-    let fun_value_binding_pexp_2 =
-      [%ocaml.error
-        "browser_only works on function definitions. If there's another case \
-         where it can be helpful, feel free to open an issue in \
-         https://github.com/ml-in-barcelona/server-reason-react."]
-    in
-    let fun_value_binding_pexp_fun_1arg =
-     fun [@warning "-27"] evt ->
-      Runtime.fail_impossible_action_in_ssr "fun_value_binding_pexp_fun_1arg"
-       [@@warning "-27-26"]
-    in
-    let fun_value_binding_pexp_fun_2arg =
-     fun [@warning "-27"] evt ->
-      fun [@warning "-27"] moar_arguments ->
-       Runtime.fail_impossible_action_in_ssr "fun_value_binding_pexp_fun_2arg"
-       [@@warning "-27-26"]
-    in
-    let fun_value_binding_labelled_args =
-     fun [@warning "-27"] ~argument1 ->
-      fun [@warning "-27"] ~argument2 ->
-       Runtime.fail_impossible_action_in_ssr "fun_value_binding_labelled_args"
-       [@@warning "-27-26"]
-    in
-    React.createElement "div"
+    (let fun_value_binding_pexp_2 =
+       [%ocaml.error
+         "browser_only works on function definitions. If there's another case \
+          where it can be helpful, feel free to open an issue in \
+          https://github.com/ml-in-barcelona/server-reason-react."]
+     in
+     (let fun_value_binding_pexp_fun_1arg =
+       fun [@warning "-27"] evt ->
+        Runtime.fail_impossible_action_in_ssr "fun_value_binding_pexp_fun_1arg"
+         [@@warning "-27-26"]
+      in
+      (let fun_value_binding_pexp_fun_2arg =
+        fun [@warning "-27"] evt ->
+         fun [@warning "-27"] moar_arguments ->
+          Runtime.fail_impossible_action_in_ssr "fun_value_binding_pexp_fun_2arg"
+          [@@warning "-27-26"]
+       in
+       (let fun_value_binding_labelled_args =
+         fun [@warning "-27"] ~argument1 ->
+          fun [@warning "-27"] ~argument2 ->
+           Runtime.fail_impossible_action_in_ssr "fun_value_binding_labelled_args"
+           [@@warning "-27-26"]
+        in
+        React.createElement "div")
+       [@warning "-27"])
+      [@warning "-27"])
+     [@warning "-27"])
+    [@warning "-27"]

--- a/packages/ppx/tests/browser_only.t/run.t
+++ b/packages/ppx/tests/browser_only.t/run.t
@@ -1,190 +1,66 @@
 With -js flag everything keeps as it is and browser_only extension disappears
 
   $ ../standalone.exe -impl input.ml -js | ocamlformat - --enable-outside-detected-project --impl
-  let _ = Webapi.Dom.getElementById "foo"
-  let valueFromEvent = Webapi.Dom.getElementById "foo"
-  let valueFromEvent evt = Webapi.Dom.getElementById "foo"
-  let valueFromEvent evt moar_arguments = Webapi.Dom.getElementById "foo"
+  let pstr_value_binding = Webapi.Dom.getElementById "foo"
+  let pstr_value_binding_2 = Webapi.Dom.getElementById "foo"
+  let pexp_fun_1arg_structure_item evt = Webapi.Dom.getElementById "foo"
+  
+  let pexp_fun_2arg_structure_item evt moar_arguments =
+    Webapi.Dom.getElementById "foo"
   
   let make () =
-    let _ = Webapi.Dom.getElementById "foo" in
-    let valueFromEvent = Webapi.Dom.getElementById "foo" in
-    let valueFromEvent evt = Webapi.Dom.getElementById "foo" in
-    let valueFromEvent evt moar_arguments = Webapi.Dom.getElementById "foo" in
-    React.createElement "div"
-  
-  let _ = Webapi.Dom.getElementById "foo"
-  let loadInitialText () = setHtmlFetchState Loading
-  let loadInitialText argument1 = setHtmlFetchState Loading
-  let loadInitialText argument1 argument2 = setHtmlFetchState Loading
-  let labeled ~argument1 ~argument2 = setHtmlFetchState Loading
-  let getById id = Webapi.Dom.getElementById id
-  
-  let make () =
-    let _ = Webapi.Dom.getElementById "foo" in
-    let loadInitialText () = setHtmlFetchState Loading in
-    let loadInitialText argument1 = setHtmlFetchState Loading in
-    let loadInitialText argument1 argument2 = setHtmlFetchState Loading in
-    let labeled ~argument1 ~argument2 = setHtmlFetchState Loading in
+    let fun_value_binding_pexp = Webapi.Dom.getElementById "foo" in
+    let fun_value_binding_pexp_2 = Webapi.Dom.getElementById "foo" in
+    let fun_value_binding_pexp_fun_1arg evt = Webapi.Dom.getElementById "foo" in
+    let fun_value_binding_pexp_fun_2arg evt moar_arguments =
+      Webapi.Dom.getElementById "foo"
+    in
+    let fun_value_binding_labelled_args ~argument1 ~argument2 =
+      setHtmlFetchState Loading
+    in
     React.createElement "div"
 
 Without -js flag, the compilation to native replaces the expression with `raise (ReactDOM.Impossible_in_ssr`
 
   $ ../standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl
-  let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById"
-  let valueFromEvent = Webapi.Dom.getElementById "foo"
+  let pstr_value_binding =
+    Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById"
   
-  let valueFromEvent evt = Runtime.fail_impossible_action_in_ssr "evt"
+  let pstr_value_binding_2 = Webapi.Dom.getElementById "foo"
+  
+  let pexp_fun_1arg_structure_item evt =
+    Runtime.fail_impossible_action_in_ssr "pexp_fun_1arg_structure_item"
   [@@warning "-27-32"]
   
-  let valueFromEvent evt moar_arguments =
-    Runtime.fail_impossible_action_in_ssr "evt"
+  let pexp_fun_2arg_structure_item evt moar_arguments =
+    Runtime.fail_impossible_action_in_ssr "pexp_fun_2arg_structure_item"
   [@@warning "-27-32"]
   
   let make () =
-    let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById" in
-    let valueFromEvent =
+    let fun_value_binding_pexp =
+      Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById"
+    in
+    let fun_value_binding_pexp_2 =
       [%ocaml.error
         "browser_only works on function definitions. If there's another case \
          where it can be helpful, feel free to open an issue in \
          https://github.com/ml-in-barcelona/server-reason-react."]
     in
-    let valueFromEvent =
+    let fun_value_binding_pexp_fun_1arg =
      fun [@warning "-27"] evt ->
-      Runtime.fail_impossible_action_in_ssr "valueFromEvent"
+      Runtime.fail_impossible_action_in_ssr "fun_value_binding_pexp_fun_1arg"
        [@@warning "-27-26"]
     in
-    let valueFromEvent =
-     fun [@warning "-27"] evt ->
-      fun [@warning "-27"] moar_arguments ->
-       Runtime.fail_impossible_action_in_ssr "valueFromEvent"
-       [@@warning "-27-26"]
-    in
-    React.createElement "div"
-  
-  let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById"
-  
-  let loadInitialText () = Runtime.fail_impossible_action_in_ssr "unkwnown"
-  [@@warning "-27-32"]
-  
-  let loadInitialText argument1 =
-    Runtime.fail_impossible_action_in_ssr "argument1"
-  [@@warning "-27-32"]
-  
-  let loadInitialText argument1 argument2 =
-    Runtime.fail_impossible_action_in_ssr "argument1"
-  [@@warning "-27-32"]
-  
-  let labeled ~argument1 ~argument2 =
-    Runtime.fail_impossible_action_in_ssr "argument1"
-  [@@warning "-27-32"]
-  
-  let getById =
-   fun [@warning "-27"] id ->
-    Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById id"
-  
-  let make () =
-    let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById" in
-    let loadInitialText =
-     fun [@warning "-27"] () ->
-      Runtime.fail_impossible_action_in_ssr "loadInitialText"
-       [@@warning "-27-26"]
-    in
-    let loadInitialText =
-     fun [@warning "-27"] argument1 ->
-      Runtime.fail_impossible_action_in_ssr "loadInitialText"
-       [@@warning "-27-26"]
-    in
-    let loadInitialText =
-     fun [@warning "-27"] argument1 ->
-      fun [@warning "-27"] argument2 ->
-       Runtime.fail_impossible_action_in_ssr "loadInitialText"
-       [@@warning "-27-26"]
-    in
-    let labeled =
-     fun [@warning "-27"] ~argument1 ->
-      fun [@warning "-27"] ~argument2 ->
-       Runtime.fail_impossible_action_in_ssr "labeled"
-       [@@warning "-27-26"]
-    in
-    React.createElement "div"
-
-
-  $ ../standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl
-  let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById"
-  let valueFromEvent = Webapi.Dom.getElementById "foo"
-  
-  let valueFromEvent evt = Runtime.fail_impossible_action_in_ssr "evt"
-  [@@warning "-27-32"]
-  
-  let valueFromEvent evt moar_arguments =
-    Runtime.fail_impossible_action_in_ssr "evt"
-  [@@warning "-27-32"]
-  
-  let make () =
-    let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById" in
-    let valueFromEvent =
-      [%ocaml.error
-        "browser_only works on function definitions. If there's another case \
-         where it can be helpful, feel free to open an issue in \
-         https://github.com/ml-in-barcelona/server-reason-react."]
-    in
-    let valueFromEvent =
-     fun [@warning "-27"] evt ->
-      Runtime.fail_impossible_action_in_ssr "valueFromEvent"
-       [@@warning "-27-26"]
-    in
-    let valueFromEvent =
+    let fun_value_binding_pexp_fun_2arg =
      fun [@warning "-27"] evt ->
       fun [@warning "-27"] moar_arguments ->
-       Runtime.fail_impossible_action_in_ssr "valueFromEvent"
+       Runtime.fail_impossible_action_in_ssr "fun_value_binding_pexp_fun_2arg"
        [@@warning "-27-26"]
     in
-    React.createElement "div"
-  
-  let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById"
-  
-  let loadInitialText () = Runtime.fail_impossible_action_in_ssr "unkwnown"
-  [@@warning "-27-32"]
-  
-  let loadInitialText argument1 =
-    Runtime.fail_impossible_action_in_ssr "argument1"
-  [@@warning "-27-32"]
-  
-  let loadInitialText argument1 argument2 =
-    Runtime.fail_impossible_action_in_ssr "argument1"
-  [@@warning "-27-32"]
-  
-  let labeled ~argument1 ~argument2 =
-    Runtime.fail_impossible_action_in_ssr "argument1"
-  [@@warning "-27-32"]
-  
-  let getById =
-   fun [@warning "-27"] id ->
-    Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById id"
-  
-  let make () =
-    let _ = Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById" in
-    let loadInitialText =
-     fun [@warning "-27"] () ->
-      Runtime.fail_impossible_action_in_ssr "loadInitialText"
-       [@@warning "-27-26"]
-    in
-    let loadInitialText =
-     fun [@warning "-27"] argument1 ->
-      Runtime.fail_impossible_action_in_ssr "loadInitialText"
-       [@@warning "-27-26"]
-    in
-    let loadInitialText =
-     fun [@warning "-27"] argument1 ->
-      fun [@warning "-27"] argument2 ->
-       Runtime.fail_impossible_action_in_ssr "loadInitialText"
-       [@@warning "-27-26"]
-    in
-    let labeled =
+    let fun_value_binding_labelled_args =
      fun [@warning "-27"] ~argument1 ->
       fun [@warning "-27"] ~argument2 ->
-       Runtime.fail_impossible_action_in_ssr "labeled"
+       Runtime.fail_impossible_action_in_ssr "fun_value_binding_labelled_args"
        [@@warning "-27-26"]
     in
     React.createElement "div"

--- a/packages/reactDom/src/dune
+++ b/packages/reactDom/src/dune
@@ -2,6 +2,6 @@
  (name reactDOM)
  (wrapped false)
  (public_name server-reason-react.reactDom)
- (libraries react js html lwt)
+ (libraries react js html lwt runtime)
  (preprocess
   (pps melange.ppx)))

--- a/packages/reactDom/src/reactDOM.ml
+++ b/packages/reactDom/src/reactDOM.ml
@@ -223,14 +223,12 @@ let renderToLwtStream element =
 
 let querySelector _str = None
 
-exception Impossible_in_ssr of string
+let render _element _node =
+  Runtime.fail_impossible_action_in_ssr "ReactDOM.render"
 
-let fail_impossible_action_in_ssr fn =
-  let msg = Printf.sprintf "'%s' shouldn't run on the server" fn in
-  raise (Impossible_in_ssr msg)
+let hydrate _element _node =
+  Runtime.fail_impossible_action_in_ssr "ReactDOM.hydrate"
 
-let render _element _node = fail_impossible_action_in_ssr "ReactDOM.render"
-let hydrate _element _node = fail_impossible_action_in_ssr "ReactDOM.hydrate"
 let createPortal _reactElement _domElement = _reactElement
 
 module Style = ReactDOMStyle

--- a/packages/reactDom/src/reactDOM.mli
+++ b/packages/reactDom/src/reactDOM.mli
@@ -9,11 +9,6 @@ val renderToLwtStream : React.element -> string Lwt_stream.t * (unit -> unit)
 
 val querySelector : 'a -> 'b option
 
-exception Impossible_in_ssr of string
-(** Exception to throw when operations aren't meant to be running on native, mostly used by browser_ppx *)
-
-val fail_impossible_action_in_ssr : string -> 'a
-
 val render : 'a -> 'b -> 'c
 (** Do nothing on the server *)
 

--- a/packages/runtime/dune
+++ b/packages/runtime/dune
@@ -1,0 +1,4 @@
+(library
+ (name runtime)
+ (modes :standard melange)
+ (public_name server-reason-react.runtime))

--- a/packages/runtime/runtime.ml
+++ b/packages/runtime/runtime.ml
@@ -1,0 +1,9 @@
+exception Impossible_in_ssr of string
+
+let fail_impossible_action_in_ssr fn =
+  raise
+    (Impossible_in_ssr
+       (Printf.sprintf
+          "'%s' shouldn't run on the server. Make sure to use it only in the \
+           client. "
+          fn))

--- a/packages/runtime/runtime.ml
+++ b/packages/runtime/runtime.ml
@@ -1,9 +1,19 @@
 exception Impossible_in_ssr of string
 
 let fail_impossible_action_in_ssr fn =
+  let backtrace = Printexc.get_callstack 8 in
+  let raw_callstack = Printexc.raw_backtrace_to_string backtrace in
+  let () =
+    Printf.printf
+      {|
+The function '%s' should only run on the client. Make sure you aren't accidentally calling this function in a server-side context.
+
+Here's the raw callstack:
+
+%s
+|}
+      fn raw_callstack
+  in
   raise
     (Impossible_in_ssr
-       (Printf.sprintf
-          "'%s' shouldn't run on the server. Make sure to use it only in the \
-           client. "
-          fn))
+       (Printf.sprintf {|The function '%s' shouldn't run on the server|} fn))

--- a/packages/runtime/runtime.mli
+++ b/packages/runtime/runtime.mli
@@ -1,0 +1,4 @@
+exception Impossible_in_ssr of string
+(** Exception to throw when operations aren't meant to be running on native, mostly used by browser_ppx or ReactDOM *)
+
+val fail_impossible_action_in_ssr : string -> 'a


### PR DESCRIPTION
Improves on the idea of https://github.com/ml-in-barcelona/server-reason-react/pull/65.

- Adds a better mechanism for printing the function names
- Adds the callstack (it can be disabled with "b")
- Exports the exception from ReactDOM into a lib called "runtime".

The output when you run client code on the server is the following:

```
// demo/index.re

let%browser_only initWebsocket = () => [%mel.raw ...]

let _ = initWebsocket();
```

```
→ make demo
opam exec -- dune exec demo/index.exe

The function 'initWebsocket' should only run on the client. Make sure you aren't accidentally calling this function in a server-side context.

Here's the raw callstack:

Raised by primitive operation at Runtime.fail_impossible_action_in_ssr in file "packages/runtime/runtime.ml", line 4, characters 18-42
Called from Shared_native__MelRaw.initWebsocket in file "demo/shared/native/lib/MelRaw.re" (inlined), line 1, characters 0-854
Called from Shared_native__MelRaw in file "demo/shared/native/lib/MelRaw.re", line 38, characters 8-23

Fatal error: exception Runtime.Impossible_in_ssr("The function 'initWebsocket' shouldn't run on the server")
make: *** [demo] Error 2
```