### PR TITLE
fix keyboard events compilation error

### DIFF
--- a/demo/shared/native/lib/SubHeader.re
+++ b/demo/shared/native/lib/SubHeader.re
@@ -37,7 +37,15 @@ let make = () => {
     <form>
       <label>
         {React.string("Name:")}
-        <input type_="text" name="name" />
+        <input
+          onKeyPress=[%browser_only
+            _ => {
+              Js.log("key pressed");
+            }
+          ]
+          type_="text"
+          name="name"
+        />
       </label>
       <input type_="submit" value="Submit" />
     </form>

--- a/packages/server-reason-react-ppx/jsx.ml
+++ b/packages/server-reason-react-ppx/jsx.ml
@@ -944,7 +944,8 @@ let makePropField ~loc id (arg_label, value) =
       [%expr
         Some
           (React.JSX.Event
-             ([%e constantString ~loc jsxName], React.JSX.Keyboard v))]
+             ( [%e constantString ~loc jsxName],
+               React.JSX.Keyboard [%e objectValue] ))]
   | Event { type_ = Keyboard; jsxName }, true ->
       [%expr
         Option.map (fun v ->


### PR DESCRIPTION
Keyboard events were generating invalid code, causing a compilation error `Error: Unbound value v`. I added an example in the demo to trigger the failure.