### PR TITLE
Align with reason-react

### DIFF
--- a/demo/server/comments.re
+++ b/demo/server/comments.re
@@ -82,7 +82,7 @@ module Data = {
 module Comments = {
   let make = () => {
     /* Sincronous data: let comments = Data.get(); */
-    let comments = React.use(Data.promise());
+    let comments = React.Experimental.use(Data.promise());
 
     <>
       {comments

--- a/packages/react/src/react.ml
+++ b/packages/react/src/react.ml
@@ -584,6 +584,7 @@ let useCallback4 fn _ = fn
 let useCallback5 fn _ = fn
 let useCallback6 fn _ = fn
 let useReducer _ s = (s, fun _ -> ())
+let useReducerWithMapState _ s mapper = (mapper s, fun _ -> ())
 let useEffect0 _ = ()
 let useEffect1 _ _ = ()
 let useEffect2 _ _ = ()

--- a/packages/react/src/react.ml
+++ b/packages/react/src/react.ml
@@ -557,19 +557,6 @@ end
 (* let memo f : 'props * 'props -> bool = f
    let memoCustomCompareProps f _compare : 'props * 'props -> bool = f *)
 
-(* `exception Suspend of 'a Lwt`
-    exceptions can't have type params, this is called existential wrapper *)
-type any_promise = Any_promise : 'a Lwt.t -> any_promise
-
-exception Suspend of any_promise
-
-let use promise =
-  match Lwt.state promise with
-  | Sleep -> raise (Suspend (Any_promise promise))
-  (* TODO: Fail should raise a FailedSupense and catch at renderTo* *)
-  | Fail e -> raise e
-  | Return v -> v
-
 let useContext context = context.current_value.current
 
 let useState (make_initial_value : unit -> 'state) =
@@ -627,3 +614,19 @@ module Children = struct
 end
 
 let setDisplayName _ _ = ()
+let useTransition () = (false, fun (_cb : unit -> unit) -> ())
+
+(* `exception Suspend of 'a Lwt`
+    exceptions can't have type params, this is called existential wrapper *)
+type any_promise = Any_promise : 'a Lwt.t -> any_promise
+
+exception Suspend of any_promise
+
+module Experimental = struct
+  let use promise =
+    match Lwt.state promise with
+    | Sleep -> raise (Suspend (Any_promise promise))
+    (* TODO: Fail should raise a FailedSupense and catch at renderTo* *)
+    | Fail e -> raise e
+    | Return v -> v
+end

--- a/packages/react/src/react.ml
+++ b/packages/react/src/react.ml
@@ -567,6 +567,12 @@ let useState (make_initial_value : unit -> 'state) =
   in
   (initial_value, setState)
 
+let internal_id = ref 0
+
+let useId () =
+  internal_id := !internal_id + 1;
+  Int.to_string !internal_id
+
 let useMemo fn = fn ()
 let useMemo0 fn = fn ()
 let useMemo1 fn _ = fn ()

--- a/packages/react/src/react.ml
+++ b/packages/react/src/react.ml
@@ -616,6 +616,9 @@ end
 let setDisplayName _ _ = ()
 let useTransition () = (false, fun (_cb : unit -> unit) -> ())
 
+let useDebugValue : 'value -> ?format:('value -> string) -> unit =
+ fun [@warning "-16"] _ ?format -> ()
+
 (* `exception Suspend of 'a Lwt`
     exceptions can't have type params, this is called existential wrapper *)
 type any_promise = Any_promise : 'a Lwt.t -> any_promise

--- a/packages/react/src/react.mli
+++ b/packages/react/src/react.mli
@@ -720,3 +720,4 @@ module Experimental : sig
 end
 
 val useTransition : unit -> bool * ((unit -> unit) -> unit)
+val useDebugValue : 'value -> ?format:('value -> string) -> unit

--- a/packages/react/src/react.mli
+++ b/packages/react/src/react.mli
@@ -614,7 +614,6 @@ type any_promise = Any_promise : 'a Lwt.t -> any_promise
 exception Suspend of any_promise
 
 (* val memo : ('props * 'props -> bool) -> 'a -> 'props * 'props -> bool *)
-val use : 'a Lwt.t -> 'a
 val useContext : 'a Context.t -> 'a
 val useState : (unit -> 'state) -> 'state * (('state -> 'state) -> unit)
 val useMemo : (unit -> 'a) -> 'a
@@ -715,3 +714,9 @@ module Children : sig
   val only : element array -> element
   val toArray : element -> element array
 end
+
+module Experimental : sig
+  val use : 'a Lwt.t -> 'a
+end
+
+val useTransition : unit -> bool * ((unit -> unit) -> unit)

--- a/packages/react/src/react.mli
+++ b/packages/react/src/react.mli
@@ -632,12 +632,16 @@ val useCallback3 : 'a -> 'b -> 'a
 val useCallback4 : 'a -> 'b -> 'a
 val useCallback5 : 'a -> 'b -> 'a
 val useCallback6 : 'a -> 'b -> 'a
+val useId : unit -> string
 
 val useReducer :
   ('state -> 'action -> 'state) -> 'state -> 'state * ('action -> unit)
 
 val useReducerWithMapState :
-  ('state -> 'action -> 'initialState) -> 'initialState -> ('initialState -> 'state) -> 'state * ('action -> unit)
+  ('state -> 'action -> 'initialState) ->
+  'initialState ->
+  ('initialState -> 'state) ->
+  'state * ('action -> unit)
 
 val useEffect0 : (unit -> (unit -> unit) option) -> unit
 val useEffect1 : (unit -> (unit -> unit) option) -> 'dependency array -> unit

--- a/packages/react/src/react.mli
+++ b/packages/react/src/react.mli
@@ -636,6 +636,9 @@ val useCallback6 : 'a -> 'b -> 'a
 val useReducer :
   ('state -> 'action -> 'state) -> 'state -> 'state * ('action -> unit)
 
+val useReducerWithMapState :
+  ('state -> 'action -> 'initialState) -> 'initialState -> ('initialState -> 'state) -> 'state * ('action -> unit)
+
 val useEffect0 : (unit -> (unit -> unit) option) -> unit
 val useEffect1 : (unit -> (unit -> unit) option) -> 'dependency array -> unit
 

--- a/packages/react/test/test.ml
+++ b/packages/react/test/test.ml
@@ -1,1 +1,1 @@
-let () = Alcotest.run "React" [ Test_cloneElement.tests ]
+let () = Alcotest.run "React" [ Test_cloneElement.tests; Test_react.tests ]

--- a/packages/react/test/test_react.ml
+++ b/packages/react/test/test_react.ml
@@ -1,0 +1,34 @@
+let assert_string left right =
+  Alcotest.check Alcotest.string "should be equal" right left
+
+let use_state_doesnt_fire () =
+  let app =
+    React.Upper_case_component
+      (fun () ->
+        let state, set_state = React.useState (fun () -> "foo") in
+        (* You wouldn't have this code in prod, but just for testing purposes *)
+        set_state (fun _prev -> "bar");
+        React.createElement "div" [||] [ React.string state ])
+  in
+  assert_string (ReactDOM.renderToStaticMarkup app) "<div>foo</div>"
+
+let use_effect_doesnt_fire () =
+  let app =
+    React.Upper_case_component
+      (fun () ->
+        let ref = React.useRef "foo" in
+        React.useEffect0 (fun () ->
+            ref.current <- "bar";
+            None);
+        React.createElement "div" [||] [ React.string ref.current ])
+  in
+  assert_string (ReactDOM.renderToStaticMarkup app) "<div>foo</div>"
+
+let case title fn = Alcotest.test_case title `Quick fn
+
+let tests =
+  ( "React",
+    [
+      case "useState" use_state_doesnt_fire;
+      case "useEffect" use_effect_doesnt_fire;
+    ] )

--- a/packages/reactDom/test/test_renderToLwtStream.ml
+++ b/packages/reactDom/test/test_renderToLwtStream.ml
@@ -40,7 +40,7 @@ let react_use_without_suspense _switch () =
   let app =
     React.Upper_case_component
       (fun () ->
-        let () = React.use (Sleep.delay delay) in
+        let () = React.Experimental.use (Sleep.delay delay) in
         React.createElement "div" [||]
           [
             React.createElement "span" [||]
@@ -80,7 +80,7 @@ let react_use_with_suspense _switch () =
   let time =
     React.Upper_case_component
       (fun () ->
-        let () = React.use (Sleep.delay delay) in
+        let () = React.Experimental.use (Sleep.delay delay) in
         React.createElement "div" [||]
           [
             React.createElement "span" [||]


### PR DESCRIPTION
- useTransition
- Moves React.use to React.Experimental.use
- useReducerWithMapState
- Dummy implements useId (opening this issue https://github.com/ml-in-barcelona/server-reason-react/issues/93)
- useDebugValue
- useDeferredValue (closes https://github.com/ml-in-barcelona/server-reason-react/issues/89)