### PR TITLE
Improve melange-ppx

### DIFF
--- a/demo/client/dune
+++ b/demo/client/dune
@@ -4,7 +4,7 @@
  (modules app)
  (libraries melange shared_js reason-react)
  (preprocess
-  (pps reason-react-ppx))
+  (pps reason-react-ppx melange_native_ppx browser_ppx -js))
  (module_systems commonjs))
 
 (melange.emit

--- a/demo/server/dune
+++ b/demo/server/dune
@@ -5,16 +5,17 @@
   shared_native
   server-reason-react.react
   server-reason-react.reactDom
+  server-reason-react.js
   lwt.unix)
  (modules :standard \ Index)
  (preprocess
-  (pps server-reason-react.ppx lwt_ppx)))
+  (pps server-reason-react.ppx server-reason-react.browser_ppx lwt_ppx)))
 
 (executable
  (name index)
  (public_name demo)
  (modules Index)
  (package server-reason-react)
- (libraries react reactDOM belt js shared_native tiny_httpd)
+ (libraries react reactDOM belt js shared_native tiny_httpd melange.dom)
  (preprocess
   (pps melange_native_ppx server-reason-react.ppx)))

--- a/demo/shared/js/dune
+++ b/demo/shared/js/dune
@@ -1,7 +1,7 @@
 (library
  (name shared_js)
  (modes melange)
- (libraries reason-react melange-webapi melange.belt)
+ (libraries reason-react melange-webapi melange.belt melange.dom)
  (preprocess
   (pps melange.ppx reason-react-ppx browser_ppx -js)))
 

--- a/demo/shared/native/dune
+++ b/demo/shared/native/dune
@@ -7,6 +7,7 @@
   server-reason-react.reactDom
   server-reason-react.js
   server-reason-react.belt
+  server-reason-react.dom
   server-reason-react.webapi)
  (preprocess
   (pps melange_native_ppx server-reason-react.ppx browser_ppx)))

--- a/demo/shared/native/lib/SubHeader.re
+++ b/demo/shared/native/lib/SubHeader.re
@@ -10,6 +10,8 @@ module Cosis = {
   };
 };
 
+let storage = Dom.Storage2.localStorage;
+
 [@react.component]
 let make = () => {
   let%browser_only onClick = _event => {

--- a/demo/shared/native/lib/SubHeader.re
+++ b/demo/shared/native/lib/SubHeader.re
@@ -10,7 +10,7 @@ module Cosis = {
   };
 };
 
-let storage = Dom.Storage2.localStorage;
+let%browser_only getStorage = () => Dom.Storage2.localStorage;
 
 [@react.component]
 let make = () => {

--- a/doc/index.mld
+++ b/doc/index.mld
@@ -62,7 +62,7 @@ let%browser_only countDomNodes = (id) => {
 };
 ]}
 
-Add [browser_ppx] to your pps in your dune files. Don't forget to add it on both "server" and "client" dune files, since you want to discard the content and add [browser_only -js] only to the client.
+Add [browser_ppx] to your pps in your dune files. Don't forget to add it on both "server" and "client" dune files, since you want to discard the content and add [browser_ppx -js] only to the client.
 
 On client's dune:
 {[ (preprocess (pps browser_ppx -js)) ]}

--- a/packages/browser-ppx/ppx.ml
+++ b/packages/browser-ppx/ppx.ml
@@ -334,6 +334,19 @@ module Browser_only = struct
                          a let%browser_only function."]) =
                   Runtime.fail_impossible_action_in_ssr [%e message]
                 [@@alert "-browser_only"]]
+          | Pexp_newtype (name, expr) ->
+              let original_function_name = name.txt in
+              let item =
+                last_expr_to_raise_impossible original_function_name expr
+              in
+              [%stri
+                let[@warning "-27-32"] ([%p pattern]
+                    [@alert
+                      browser_only
+                        "This expression is marked to only run on the browser \
+                         where JavaScript can run. You can only use it inside \
+                         a let%browser_only function."]) =
+                  ([%e item] [@alert "-browser_only"])]
           | _expr -> do_nothing rec_flag)
     in
     Context_free.Rule.extension

--- a/packages/browser-ppx/tests/pexp_constraint.t
+++ b/packages/browser-ppx/tests/pexp_constraint.t
@@ -6,6 +6,24 @@
   >   ();
   > };
   > 
+  > let%browser_only reifyStyle = (type a, x: 'a): (style(a), a) => {
+  >     let isCanvasGradient = _ => false;
+  >     let isCanvasPattern = _ => false;
+  >     
+  >     (
+  >       if (Js.typeof(x) == "string") {
+  >         Obj.magic(String);
+  >       } else if (isCanvasGradient(x)) {
+  >         Obj.magic(Gradient);
+  >       } else if (isCanvasPattern(x)) {
+  >         Obj.magic(Pattern);
+  >       } else {
+  >         invalid_arg("Unknown canvas style kind. Known values are: String, CanvasGradient, CanvasPattern");
+  >       },
+  >       Obj.magic(x),
+  >     );
+  >   };
+  > 
   > EOF
 
   $ refmt --print ml input.re > input.ml
@@ -15,6 +33,24 @@
   let make = () => {
     let discard: Js.Promise.t(unit) => unit = value => ignore(value);
     ();
+  };
+  let reifyStyle = (type a, x: 'a): (style(a), a) => {
+    let isCanvasGradient = _ => false;
+    let isCanvasPattern = _ => false;
+    (
+      if (Js.typeof(x) == "string") {
+        Obj.magic(String);
+      } else if (isCanvasGradient(x)) {
+        Obj.magic(Gradient);
+      } else if (isCanvasPattern(x)) {
+        Obj.magic(Pattern);
+      } else {
+        invalid_arg(
+          "Unknown canvas style kind. Known values are: String, CanvasGradient, CanvasPattern",
+        );
+      },
+      Obj.magic(x),
+    );
   };
 
   $ ./standalone.exe -impl input.ml | refmt --parse ml --print re
@@ -35,3 +71,12 @@
     let discard = value => Runtime.fail_impossible_action_in_ssr("discard");
     ();
   };
+  [@warning "-27-32"]
+  let [@alert
+        browser_only(
+          "This expression is marked to only run on the browser where JavaScript can run. You can only use it inside a let%browser_only function.",
+        )
+      ]
+      reifyStyle =
+    [@alert "-browser_only"]
+    ((x: 'a) => Runtime.fail_impossible_action_in_ssr("a"));

--- a/packages/melange.dom/dom_storage2.ml
+++ b/packages/melange.dom/dom_storage2.ml
@@ -1,27 +1,15 @@
 type t
 
-(* external getItem : string -> string option = "getItem"
-   [@@mel.send.pipe: t] [@@mel.return null_to_opt] *)
-let getItem _k = None
+external getItem : string -> string option = "getItem"
+[@@mel.send.pipe: t] [@@mel.return null_to_opt]
 
-(* external setItem : string -> string -> unit = "setItem" [@@mel.send.pipe: t] *)
-let setItem _k _v = ()
+external setItem : string -> string -> unit = "setItem" [@@mel.send.pipe: t]
+external removeItem : string -> unit = "removeItem" [@@mel.send.pipe: t]
+external clear : unit -> unit = "clear" [@@mel.send.pipe: t]
 
-(* external removeItem : string -> unit = "removeItem" [@@mel.send.pipe: t] *)
-let removeItem _k = ()
+external key : int -> string option = "key"
+[@@mel.send.pipe: t] [@@mel.return null_to_opt]
 
-(* external clear : unit -> unit = "clear" [@@mel.send.pipe: t] *)
-let clear _ = ()
-
-(* external key : int -> string option = "key"
-   [@@mel.send.pipe: t] [@@mel.return null_to_opt] *)
-let key _ = None
-
-(* external length : t -> int = "length" [@@mel.get] *)
-let length _ = 0
-
-(* external localStorage : t = "localStorage" *)
-let localStorage = assert false
-
-(* external sessionStorage : t = "sessionStorage" *)
-let sessionStorage = assert false
+external length : t -> int = "length" [@@mel.get]
+external localStorage : t = "localStorage"
+external sessionStorage : t = "sessionStorage"

--- a/packages/melange.dom/dune
+++ b/packages/melange.dom/dune
@@ -1,3 +1,5 @@
 (library
  (name dom)
- (public_name server-reason-react.dom))
+ (public_name server-reason-react.dom)
+ (preprocess
+  (pps server-reason-react.melange.ppx)))

--- a/packages/melange.dom/dune
+++ b/packages/melange.dom/dune
@@ -1,4 +1,3 @@
 (library
  (name dom)
- (public_name server-reason-react.dom)
- (wrapped false))
+ (public_name server-reason-react.dom))

--- a/packages/melange.ppx/dune
+++ b/packages/melange.ppx/dune
@@ -1,6 +1,7 @@
 (library
  (name melange_native_ppx)
  (public_name server-reason-react.melange.ppx)
+ (ppx_runtime_libraries server-reason-react.runtime)
  (flags :standard -w -9)
  (libraries ppxlib ppxlib.astlib str)
  (preprocess

--- a/packages/melange.ppx/tests/external.t
+++ b/packages/melange.ppx/tests/external.t
@@ -9,6 +9,19 @@ mel.as attribute
   type t
   
   let (document : t) =
-    raise (Failure "called Melange external \"mel.\" from native")
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "document")
 
-  $ ocamlc output.ml
+  $ echo "module Runtime = struct" > main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ echo "end" >> main.ml
+  $ cat output.ml >> main.ml
+  $ ocamlc -c main.ml

--- a/packages/melange.ppx/tests/mel_as.t
+++ b/packages/melange.ppx/tests/mel_as.t
@@ -5,4 +5,14 @@ mel.as attribute
 
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
   let (get : t -> (_[@mel.as {json|{}|json}]) -> t) =
-   fun _ -> raise (Failure "called Melange external \"mel.\" from native")
+   fun _ ->
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "get")

--- a/packages/melange.ppx/tests/mel_raw.t
+++ b/packages/melange.ppx/tests/mel_raw.t
@@ -11,9 +11,16 @@ mel.raw as a value
           "Since it's a [%mel.raw ...]. This expression is marked to only run on \
            the browser where JavaScript can run. You can only use it inside a \
            let%browser_only function."]) =
-    raise (Failure "called Melange external \"mel.\" from native")
-
-  $ ocamlc output.ml
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "value")
 
 mel.raw as an unary function
 
@@ -28,9 +35,17 @@ mel.raw as an unary function
           "Since it's a [%mel.raw ...]. This expression is marked to only run on \
            the browser where JavaScript can run. You can only use it inside a \
            let%browser_only function."]) =
-   fun _ -> raise (Failure "called Melange external \"mel.\" from native")
-
-  $ ocamlc output.ml
+   fun _ ->
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "unary_function")
 
 mel.raw as an binary function
 
@@ -48,9 +63,17 @@ mel.raw as an binary function
           "Since it's a [%mel.raw ...]. This expression is marked to only run on \
            the browser where JavaScript can run. You can only use it inside a \
            let%browser_only function."]) =
-   fun _ _ -> raise (Failure "called Melange external \"mel.\" from native")
-
-  $ ocamlc output.ml
+   fun _ _ ->
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "binary_function")
 
 mel.raw with type
 
@@ -68,9 +91,16 @@ mel.raw with type
           "Since it's a [%mel.raw ...]. This expression is marked to only run on \
            the browser where JavaScript can run. You can only use it inside a \
            let%browser_only function."]) =
-    raise (Failure "called Melange external \"mel.\" from native")
-
-  $ ocamlc output.ml
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "")
 
 mel.raw as a value
 
@@ -80,5 +110,3 @@ mel.raw as a value
 
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
   ()
-
-  $ ocamlc output.ml

--- a/packages/melange.ppx/tests/mel_send.t
+++ b/packages/melange.ppx/tests/mel_send.t
@@ -1,5 +1,5 @@
 Labelled args with @@mel.send
-  $ cat > input.ml <<EOF
+  $ cat > input.ml << EOF
   > external init : string -> param:int -> string = "init" [@@mel.send]
   > EOF
 
@@ -12,7 +12,7 @@ Labelled args with @@mel.send
 
 Labelled and unlabelled args with @@mel.obj
 
-  $ cat > input.ml <<EOF
+  $ cat > input.ml << EOF
   > external makeInitParam : onLoad:string -> unit -> string = "" [@@mel.obj]
   > EOF
 
@@ -25,7 +25,7 @@ Labelled and unlabelled args with @@mel.obj
 
 Only unlabelled
 
-  $ cat > input.ml <<EOF
+  $ cat > input.ml << EOF
   > type keycloak
   > external keycloak : string -> keycloak = "default" [@@mel.module]
   > EOF

--- a/packages/melange.ppx/tests/mel_send.t
+++ b/packages/melange.ppx/tests/mel_send.t
@@ -6,9 +6,22 @@ Labelled args with @@mel.send
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
   let (init : string -> param:int -> string) =
    fun _ ~param:_ ->
-    raise (Failure "called Melange external \"mel.\" from native")
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "init")
 
-  $ ocamlc output.ml
+  $ echo "module Runtime = struct" > main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ echo "end" >> main.ml
+  $ cat output.ml >> main.ml
+  $ ocamlc -c main.ml
 
 Labelled and unlabelled args with @@mel.obj
 
@@ -19,9 +32,22 @@ Labelled and unlabelled args with @@mel.obj
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
   let (makeInitParam : onLoad:string -> unit -> string) =
    fun ~onLoad:_ _ ->
-    raise (Failure "called Melange external \"mel.\" from native")
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "makeInitParam")
 
-  $ ocamlc output.ml
+  $ echo "module Runtime = struct" > main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ echo "end" >> main.ml
+  $ cat output.ml >> main.ml
+  $ ocamlc -c main.ml
 
 Only unlabelled
 
@@ -34,9 +60,23 @@ Only unlabelled
   type keycloak
   
   let (keycloak : string -> keycloak) =
-   fun _ -> raise (Failure "called Melange external \"mel.\" from native")
+   fun _ ->
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "keycloak")
 
-  $ ocamlc output.ml
+  $ echo "module Runtime = struct" > main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ echo "end" >> main.ml
+  $ cat output.ml >> main.ml
+  $ ocamlc -c main.ml
 
 Multiple args with optional
 
@@ -50,9 +90,22 @@ Multiple args with optional
   
   let (keycloak : ?z:int -> int -> foo:string -> keycloak) =
    fun ?z:_ _ ~foo:_ ->
-    raise (Failure "called Melange external \"mel.\" from native")
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "keycloak")
 
-  $ ocamlc output.ml
+  $ echo "module Runtime = struct" > main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ echo "end" >> main.ml
+  $ cat output.ml >> main.ml
+  $ ocamlc -c main.ml
 
 Single type (invalid OCaml, but valid in Melange)
 
@@ -65,9 +118,22 @@ Single type (invalid OCaml, but valid in Melange)
   type keycloak
   
   let (keycloak : keycloak) =
-    raise (Failure "called Melange external \"mel.\" from native")
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "keycloak")
 
-  $ ocamlc output.ml
+  $ echo "module Runtime = struct" > main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ echo "end" >> main.ml
+  $ cat output.ml >> main.ml
+  $ ocamlc -c main.ml
 
 mel.send
 
@@ -80,6 +146,20 @@ mel.send
   type t
   
   let (fillStyle : t -> 'a) =
-   fun _ -> raise (Failure "called Melange external \"mel.\" from native")
+   fun _ ->
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "fillStyle")
 
-  $ ocamlc output.ml
+  $ echo "module Runtime = struct" > main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ echo "end" >> main.ml
+  $ cat output.ml >> main.ml
+  $ ocamlc -c main.ml

--- a/packages/melange.ppx/tests/mel_send_pipe.t
+++ b/packages/melange.ppx/tests/mel_send_pipe.t
@@ -6,14 +6,23 @@ both on the type annotation, also on the function expression.
 
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
   let (getPropertyPriority : string -> t -> string) =
-   fun _ _ -> raise (Failure "called Melange external \"mel.\" from native")
+   fun _ _ ->
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "getPropertyPriority")
 
-  $ ocamlc output.ml
-  File "output.ml", line 1, characters 37-38:
-  1 | let (getPropertyPriority : string -> t -> string) =
-                                           ^
-  Error: Unbound type constructor t
-  [2]
+  $ echo "type t" > main.ml
+  $ echo "module Runtime = struct" >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ echo "end" >> main.ml
+  $ ocamlc -c main.ml
 
 Make sure is placed correctly
   $ cat > input.ml << EOF
@@ -28,14 +37,24 @@ Make sure is placed correctly
         t ->
         Dom.documentType) =
    fun ~qualifiedName:_ ~publicId:_ ~systemId:_ _ ->
-    raise (Failure "called Melange external \"mel.\" from native")
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "createDocumentType")
 
-  $ ocamlc output.ml
-  File "output.ml", line 5, characters 6-7:
-  5 |       t ->
-            ^
-  Error: Unbound type constructor t
-  [2]
+  $ echo "type t" > main.ml
+  $ echo "module Dom = struct type documentType end" >> main.ml
+  $ echo "module Runtime = struct" >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ echo "end" >> main.ml
+  $ cat output.ml >> main.ml
+  $ ocamlc -c main.ml
 
 Single argument (Ptyp_constr)
   $ cat > input.ml << EOF
@@ -43,7 +62,17 @@ Single argument (Ptyp_constr)
 
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
   let (arrayBuffer : arrayBuffer Js.Promise.t -> T.t) =
-   fun _ -> raise (Failure "called Melange external \"mel.\" from native")
+   fun _ ->
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "arrayBuffer")
 
 Labelled arguments
   $ cat > input.ml << EOF
@@ -55,9 +84,22 @@ Labelled arguments
   
   let (scale : x:float -> y:float -> t -> unit) =
    fun ~x:_ ~y:_ _ ->
-    raise (Failure "called Melange external \"mel.\" from native")
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "scale")
 
-  $ ocamlc output.ml
+  $ echo "module Runtime = struct" > main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ echo "end" >> main.ml
+  $ cat output.ml >> main.ml
+  $ ocamlc -c main.ml
 
 Nonlabelled arguments as functions
   $ cat > input.ml << EOF
@@ -68,9 +110,23 @@ Nonlabelled arguments as functions
   type t
   
   let (forEach : (string -> int -> unit) -> t -> unit) =
-   fun _ _ -> raise (Failure "called Melange external \"mel.\" from native")
+   fun _ _ ->
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "forEach")
 
-  $ ocamlc output.ml
+  $ echo "module Runtime = struct" > main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ echo "end" >> main.ml
+  $ cat output.ml >> main.ml
+  $ ocamlc -c main.ml
 
 'a
   $ cat > input.ml << EOF
@@ -78,9 +134,23 @@ Nonlabelled arguments as functions
 
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
   let (postMessage : 'a -> string -> unit) =
-   fun _ _ -> raise (Failure "called Melange external \"mel.\" from native")
+   fun _ _ ->
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "postMessage")
 
-  $ ocamlc output.ml
+  $ echo "module Runtime = struct" > main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ echo "end" >> main.ml
+  $ cat output.ml >> main.ml
+  $ ocamlc -c main.ml
 
 Send pipe with 'a
   $ cat > input.ml << EOF
@@ -88,4 +158,14 @@ Send pipe with 'a
 
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
   let (postMessage : 'a -> t_window -> string -> unit) =
-   fun _ _ _ -> raise (Failure "called Melange external \"mel.\" from native")
+   fun _ _ _ ->
+    let () =
+      Printf.printf
+        {|
+  There has been a call to a Melange's external [@mel.blabla] from native code.
+  
+  External bindings are used to communicate with JavaScript code, which can't run on the server and should be wrapped with browser_only ppx or only run it only on the client side. If there's any issue, try wrapping the expression with a try/catch as a workaround.
+  
+  |}
+    in
+    raise (Runtime.fail_impossible_action_in_ssr "postMessage")

--- a/packages/runtime/runtime.ml
+++ b/packages/runtime/runtime.ml
@@ -6,7 +6,7 @@ let fail_impossible_action_in_ssr fn =
   let () =
     Printf.printf
       {|
-The function '%s' should only run on the client. Make sure you aren't accidentally calling this function in a server-side context.
+'%s' should only run on the client. Make sure you aren't accidentally calling this function in a server-side context.
 
 Here's the raw callstack:
 
@@ -15,5 +15,4 @@ Here's the raw callstack:
       fn raw_callstack
   in
   raise
-    (Impossible_in_ssr
-       (Printf.sprintf {|The function '%s' shouldn't run on the server|} fn))
+    (Impossible_in_ssr (Printf.sprintf {|'%s' shouldn't run on the server|} fn))

--- a/packages/server-reason-react-ppx/cram/locations.t/run.t
+++ b/packages/server-reason-react-ppx/cram/locations.t/run.t
@@ -8,7 +8,7 @@ Test some locations
   > (using melange 0.1)
   > EOF
 
-  $ cat > dune <<EOF
+  $ cat > dune << EOF
   > (library
   >  (libraries server-reason-react.react server-reason-react.reactDom)
   >  (public_name test)

--- a/packages/webapi/src/Canvas/Webapi__Canvas__Canvas2d.re
+++ b/packages/webapi/src/Canvas/Webapi__Canvas__Canvas2d.re
@@ -1,3 +1,5 @@
+[@warning "-32"]; /* Since we tag with browser_only, there are 2 bindings that aren't used */
+
 type t; /* Main type, representing the 2d canvas rendering context object */
 type gradient;
 type pattern;
@@ -136,7 +138,7 @@ let setStrokeStyle = (type a, ctx: t, _: style(a), v: a) =>
 let setFillStyle = (type a, ctx: t, _: style(a), v: a) =>
   setFillStyle(ctx, v);
 
-let reifyStyle = (type a, x: 'a): (style(a), a) => {
+let%browser_only reifyStyle = (type a, x: 'a): (style(a), a) => {
   let isCanvasGradient = _ => false;
   let isCanvasPattern = _ => false;
 
@@ -159,8 +161,8 @@ let reifyStyle = (type a, x: 'a): (style(a), a) => {
 [@mel.get] external fillStyle: t => 'a = "fillStyle";
 [@mel.get] external strokeStyle: t => 'a = "strokeStyle";
 
-let fillStyle = (ctx: t) => ctx |> fillStyle |> reifyStyle;
-let strokeStyle = (ctx: t) => ctx |> strokeStyle |> reifyStyle;
+let%browser_only fillStyle = (ctx: t) => ctx |> fillStyle |> reifyStyle;
+let%browser_only strokeStyle = (ctx: t) => ctx |> strokeStyle |> reifyStyle;
 
 [@mel.set] external shadowOffsetX: (t, float) => unit = "shadowOffsetX";
 [@mel.set] external shadowOffsetY: (t, float) => unit = "shadowOffsetY";

--- a/packages/webapi/src/Fetch.ml
+++ b/packages/webapi/src/Fetch.ml
@@ -441,8 +441,7 @@ module FormData = struct
   module EntryValue = struct
     type t
 
-    let classify : t -> [> `String of string | `File of file ] =
-     fun t ->
+    let%browser_only classify t =
       if Js.typeof t = "string" then `String (Obj.magic t)
       else `File (Obj.magic t)
   end


### PR DESCRIPTION
- Improve error message when calling an external in native code
- Rollback melange.dom to original externals (with melange-ppx)
- Fix Pexp_newtype case for browser_only (and fix Canvas2d)
- Compile webapi without warnings