### PR TITLE
make demo exe private

### DIFF
--- a/demo/server/dune
+++ b/demo/server/dune
@@ -7,9 +7,7 @@
 
 (executable
  (name index)
- (public_name demo)
  (modules Index)
- (package server-reason-react)
  (libraries react reactDOM belt js shared_native tiny_httpd melange.dom)
  (preprocess
   (pps melange_native_ppx ppx)))


### PR DESCRIPTION
otherwise installation would fail with

```
# File "demo/server/dune", line 12, characters 49-59:
# 12 |  (libraries react reactDOM belt js shared_native tiny_httpd melange.dom)
#                                                       ^^^^^^^^^^
# Error: Library "tiny_httpd" not found.
```