### PR TITLE
[ppx] don't use `Option.map`

### DIFF
--- a/packages/server-reason-react-ppx/cram/lower.t/run.t
+++ b/packages/server-reason-react-ppx/cram/lower.t/run.t
@@ -38,11 +38,13 @@
       List.filter_map(
         Fun.id,
         [
-          Option.map(
-            v =>
+          switch ((tabIndex: option(int))) {
+          | None => None
+          | Some(v) =>
+            Some(
               [@implicit_arity] React.JSX.String("tabindex", string_of_int(v)),
-            tabIndex: option(int),
-          ),
+            )
+          },
         ],
       ),
       [],
@@ -294,11 +296,13 @@
       List.filter_map(
         Fun.id,
         [
-          Option.map(
-            v =>
+          switch ((onClick: option(React.Event.Mouse.t => unit))) {
+          | None => None
+          | Some(v) =>
+            Some(
               [@implicit_arity] React.JSX.Event("onClick", React.JSX.Mouse(v)),
-            onClick: option(React.Event.Mouse.t => unit),
-          ),
+            )
+          },
         ],
       ),
       [],


### PR DESCRIPTION
Referencing an `Option` module directly is problematic because users might have redefined this module in their apps, leading to compilation errors if `map` is not available, or the order of params is changed.

The PR replaces all instances where the PPX would generate code with `Option.map` with plain `match..with` statements over the optional value. That way the problem is prevented (and the generated code should be a little bit faster).