### PR TITLE
Treat mel.obj as OCaml object

### DIFF
--- a/packages/browser-ppx/tests/structure_item.t
+++ b/packages/browser-ppx/tests/structure_item.t
@@ -102,6 +102,6 @@ With -js flag everything keeps as it is and browser_only extension disappears
 
 Replace Runtime.fail_impossible_action_in_ssr with print_endline so ocamlc can compile it without the Runtime module dependency
   $ echo "module Runtime = struct" >> output.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> output.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> output.ml
   $ echo "end" >> output.ml
   $ ocamlc -c output.ml

--- a/packages/melange.ppx/ppx.ml
+++ b/packages/melange.ppx/ppx.ml
@@ -207,6 +207,20 @@ let transform_external_arrow ~loc pval_name pval_attributes pval_type =
   let vb = Builder.value_binding ~loc ~pat ~expr:function_expression in
   Ast_helper.Str.value Nonrecursive [ vb ]
 
+let ptyp_humanize = function
+  | Ptyp_tuple _ -> "Tuples"
+  | Ptyp_object _ -> "Objects"
+  | Ptyp_class _ -> "Classes"
+  | Ptyp_variant _ -> "Variants"
+  | Ptyp_extension _ -> "Extensions"
+  | Ptyp_alias _ -> "Alias"
+  | Ptyp_poly _ -> "Polyvariants"
+  | Ptyp_package _ -> "Packages"
+  | Ptyp_any -> "Any"
+  | Ptyp_var _ -> "Var"
+  | Ptyp_arrow _ -> "Arrow"
+  | Ptyp_constr _ -> "Constr"
+
 let transform_external pval_name pval_attributes pval_loc pval_type =
   let loc = pval_loc in
   match pval_type.ptyp_desc with
@@ -237,46 +251,11 @@ let transform_external pval_name pval_attributes pval_loc pval_type =
           }
         in
         [%stri let [%p pattern] = Obj.magic ()]
-  | Ptyp_tuple _ ->
-      [%stri
-        [%ocaml.error
-          "server-reason-react.melange_ppx: Tuples are not supported in native \
-           externals the same way as melange.ppx support them."]]
-  | Ptyp_object _ ->
-      [%stri
-        [%ocaml.error
-          "server-reason-react.melange_ppx: Objects are not supported in \
-           native externals the same way as melange.ppx support them."]]
-  | Ptyp_class _ ->
-      [%stri
-        [%ocaml.error
-          "server-reason-react.melange_ppx: Classes are not supported in \
-           native externals the same way as melange.ppx support them."]]
-  | Ptyp_variant _ ->
-      [%stri
-        [%ocaml.error
-          "server-reason-react.melange_ppx: Variants are not supported in \
-           native externals the same way as melange.ppx support them."]]
-  | Ptyp_extension _ ->
-      [%stri
-        [%ocaml.error
-          "server-reason-react.melange_ppx: Extensions are not supported in \
-           native externals the same way as melange.ppx support them."]]
-  | Ptyp_alias _ ->
-      [%stri
-        [%ocaml.error
-          "server-reason-react.melange_ppx: Variants are not supported in \
-           native externals the same way as melange.ppx support them."]]
-  | Ptyp_poly _ ->
-      [%stri
-        [%ocaml.error
-          "server-reason-react.melange_ppx: Polyvariants are not supported in \
-           native externals the same way as melange.ppx support them."]]
-  | Ptyp_package _ ->
-      [%stri
-        [%ocaml.error
-          "server-reason-react.melange_ppx: Packages are not supported in \
-           native externals the same way as melange.ppx support them."]]
+  | _ ->
+      Location.raise_errorf ~loc
+        "[server-reason-react.melange_ppx] %s are not supported in native \
+         externals the same way as melange.ppx support them."
+        (ptyp_humanize pval_type.ptyp_desc)
 
 let tranform_record_to_object ~loc (record : (longident_loc * expression) list)
     =
@@ -288,7 +267,8 @@ let tranform_record_to_object ~loc (record : (longident_loc * expression) list)
           | Lident label -> label
           | Ldot _ | Lapply _ ->
               Location.raise_errorf ~loc
-                "`%%mel.obj' literals only support labels"
+                "[server-reason-react.melange_ppx] Js.t objects only support \
+                 labels as keys"
         in
         Builder.pcf_method ~loc
           ( Builder.Located.mk label ~loc,
@@ -317,8 +297,10 @@ class raise_exception_mapper =
                 };
               ] ) ->
           tranform_record_to_object ~loc:pexp_loc record
-      | Pexp_extension ({ txt = "mel.obj"; loc }, _) ->
-          [%expr [%ocaml.error "%%mel.obj requires a record literal"]]
+      | Pexp_extension ({ txt = "mel.obj"; loc = _ }, _) ->
+          Location.raise_errorf ~loc:expr.pexp_loc
+            "[server-reason-react.melange_ppx] Js.t objects requires a record \
+             literal"
       | _ -> super#expression expr
 
     method! structure_item item =

--- a/packages/melange.ppx/tests/external.t
+++ b/packages/melange.ppx/tests/external.t
@@ -16,7 +16,7 @@ mel.as attribute
     Obj.magic ()
 
   $ echo "module Runtime = struct" > main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml

--- a/packages/melange.ppx/tests/mel_obj.t
+++ b/packages/melange.ppx/tests/mel_obj.t
@@ -20,14 +20,12 @@ Fail if the object is not a record
   > EOF
 
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
-  let a = [%ocaml.error "%%mel.obj requires a record literal"]
+  File "input.ml", line 1, characters 8-25:
+  1 | let a = [%mel.obj "hola"]
+              ^^^^^^^^^^^^^^^^^
+  Error: server-reason-react.melange_ppx: Js.t objects requires a record literal
 
   $ ocamlc -c output.ml
-  File "output.ml", line 1, characters 10-21:
-  1 | let a = [%ocaml.error "%%mel.obj requires a record literal"]
-                ^^^^^^^^^^^
-  Error: %%mel.obj requires a record literal
-  [2]
 
 Fail if the object is not a record
 
@@ -39,6 +37,6 @@ Fail if the object is not a record
   File "input.ml", line 1, characters 18-42:
   1 | let a = [%mel.obj { Lola.cositas = "hola"}]
                         ^^^^^^^^^^^^^^^^^^^^^^^^
-  Error: `%mel.obj' literals only support labels
+  Error: server-reason-react.melange_ppx: Js.t objects only support labels as keys
 
   $ ocamlc -c output.ml

--- a/packages/melange.ppx/tests/mel_obj.t
+++ b/packages/melange.ppx/tests/mel_obj.t
@@ -1,0 +1,44 @@
+Transform mel.obj into OCaml object literals
+
+  $ cat > input.ml << EOF
+  > let a = [%mel.obj { lola = 33; cositas = "hola"}]
+  > EOF
+
+  $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
+  let a =
+    object
+      method lola = 33
+      method cositas = "hola"
+    end
+
+  $ ocamlc -c output.ml
+
+Fail if the object is not a record
+
+  $ cat > input.ml << EOF
+  > let a = [%mel.obj "hola"]
+  > EOF
+
+  $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
+  let a = [%ocaml.error "%%mel.obj requires a record literal"]
+
+  $ ocamlc -c output.ml
+  File "output.ml", line 1, characters 10-21:
+  1 | let a = [%ocaml.error "%%mel.obj requires a record literal"]
+                ^^^^^^^^^^^
+  Error: %%mel.obj requires a record literal
+  [2]
+
+Fail if the object is not a record
+
+  $ cat > input.ml << EOF
+  > let a = [%mel.obj { Lola.cositas = "hola"}]
+  > EOF
+
+  $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
+  File "input.ml", line 1, characters 18-42:
+  1 | let a = [%mel.obj { Lola.cositas = "hola"}]
+                        ^^^^^^^^^^^^^^^^^^^^^^^^
+  Error: `%mel.obj' literals only support labels
+
+  $ ocamlc -c output.ml

--- a/packages/melange.ppx/tests/mel_raw.t
+++ b/packages/melange.ppx/tests/mel_raw.t
@@ -65,7 +65,7 @@ mel.raw with type
     Obj.magic ()
 
   $ echo "module Runtime = struct" > main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml

--- a/packages/melange.ppx/tests/mel_send.t
+++ b/packages/melange.ppx/tests/mel_send.t
@@ -18,7 +18,7 @@ Labelled args with @@mel.send
     raise (Runtime.fail_impossible_action_in_ssr "init")
 
   $ echo "module Runtime = struct" > main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml
@@ -44,7 +44,7 @@ Labelled and unlabelled args with @@mel.obj
     raise (Runtime.fail_impossible_action_in_ssr "makeInitParam")
 
   $ echo "module Runtime = struct" > main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml
@@ -73,7 +73,7 @@ Only unlabelled
     raise (Runtime.fail_impossible_action_in_ssr "keycloak")
 
   $ echo "module Runtime = struct" > main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml
@@ -102,7 +102,7 @@ Multiple args with optional
     raise (Runtime.fail_impossible_action_in_ssr "keycloak")
 
   $ echo "module Runtime = struct" > main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml
@@ -125,7 +125,7 @@ Single type (invalid OCaml, but valid in Melange)
     Obj.magic ()
 
   $ echo "module Runtime = struct" > main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml
@@ -154,7 +154,7 @@ mel.send
     raise (Runtime.fail_impossible_action_in_ssr "fillStyle")
 
   $ echo "module Runtime = struct" > main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml

--- a/packages/melange.ppx/tests/mel_send_pipe.t
+++ b/packages/melange.ppx/tests/mel_send_pipe.t
@@ -19,7 +19,7 @@ both on the type annotation, also on the function expression.
     raise (Runtime.fail_impossible_action_in_ssr "getPropertyPriority")
 
   $ echo "module Runtime = struct" >> main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ ocamlc -c main.ml
 
@@ -50,7 +50,7 @@ Make sure is placed correctly
   $ echo "type t" > main.ml
   $ echo "module Dom = struct type documentType end" >> main.ml
   $ echo "module Runtime = struct" >> main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml
@@ -95,7 +95,7 @@ Labelled arguments
     raise (Runtime.fail_impossible_action_in_ssr "scale")
 
   $ echo "module Runtime = struct" > main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml
@@ -122,7 +122,7 @@ Nonlabelled arguments as functions
     raise (Runtime.fail_impossible_action_in_ssr "forEach")
 
   $ echo "module Runtime = struct" > main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml
@@ -146,7 +146,7 @@ Nonlabelled arguments as functions
     raise (Runtime.fail_impossible_action_in_ssr "postMessage")
 
   $ echo "module Runtime = struct" > main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml
@@ -173,7 +173,7 @@ Send pipe with 'a
     raise (Runtime.fail_impossible_action_in_ssr "postMessage")
 
   $ echo "module Runtime = struct" > main.ml
-  $ cat $INSIDE_DUNE/packages/runtime/runtime.ml >> main.ml
+  $ cat $INSIDE_DUNE/packages/runtime/Runtime.ml >> main.ml
   $ echo "end" >> main.ml
   $ cat output.ml >> main.ml
   $ ocamlc -c main.ml

--- a/packages/react/src/React.ml
+++ b/packages/react/src/React.ml
@@ -348,7 +348,7 @@ module JSX = struct
   let style value = Style value
   let int key value = String (key, string_of_int value)
   let float key value = String (key, string_of_float value)
-  let dangerouslyInnerHtml value = DangerouslyInnerHtml value
+  let dangerouslyInnerHtml value = DangerouslyInnerHtml value#__html
   let ref value = Ref value
   let event key value = Event (key, value)
 

--- a/packages/react/src/React.mli
+++ b/packages/react/src/React.mli
@@ -527,7 +527,7 @@ module JSX : sig
   val bool : string -> bool -> prop
   val string : string -> string -> prop
   val style : string -> prop
-  val dangerouslyInnerHtml : string -> prop
+  val dangerouslyInnerHtml : < __html : string ; .. > -> prop
   val int : string -> int -> prop
   val float : string -> float -> prop
   val ref : domRef -> prop

--- a/packages/reactDom/src/ReactDOM.ml
+++ b/packages/reactDom/src/ReactDOM.ml
@@ -243,7 +243,7 @@ let createDOMElementVariadic (tag : string) ~props
 let add kind value map =
   match value with Some i -> map |> List.cons (kind i) | None -> map
 
-type dangerouslySetInnerHTML = { __html : string } [@@boxed]
+type dangerouslySetInnerHTML = < __html : string >
 
 (* `Booleanish_string` are JSX attributes represented as boolean values but rendered as strings on HTML https://github.com/facebook/react/blob/a17467e7e2cd8947c595d1834889b5d184459f12/packages/react-dom-bindings/src/server/ReactFizzConfigDOM.js#L1165-L1176 *)
 let booleanish_string name v = JSX.string name (string_of_bool v)
@@ -1232,7 +1232,7 @@ let domProps
   |> add (JSX.string "resource") resource
   |> add (JSX.string "typeof") typeof
   |> add (JSX.string "vocab") vocab
-  |> add (fun v -> JSX.dangerouslyInnerHtml v.__html) dangerouslySetInnerHTML
+  |> add (JSX.dangerouslyInnerHtml) dangerouslySetInnerHTML
   |> add (JSX.bool "suppressContentEditableWarning") suppressContentEditableWarning
   |> add (JSX.bool "suppressHydrationWarning") suppressHydrationWarning
 

--- a/packages/reactDom/src/ReactDOM.mli
+++ b/packages/reactDom/src/ReactDOM.mli
@@ -37,7 +37,7 @@ val createDOMElementVariadic :
   string -> props:React.JSX.prop list -> React.element array -> React.element
 (** Create a React.element by giving the HTML tag, an array of props and children *)
 
-type dangerouslySetInnerHTML = { __html : string } [@@boxed]
+type dangerouslySetInnerHTML = < __html : string >
 
 (* JSX props for HTML and SVG elements, including React specific ones. *)
 val domProps :

--- a/packages/server-reason-react-ppx/cram/lower.t/run.t
+++ b/packages/server-reason-react-ppx/cram/lower.t/run.t
@@ -31,7 +31,7 @@
       "div",
       Stdlib.List.filter_map(
         Fun.id,
-        [Some(React.JSX.DangerouslyInnerHtml(text))],
+        [Some(React.JSX.dangerouslyInnerHtml({"__html": text}))],
       ),
       [],
     );

--- a/packages/server-reason-react-ppx/server_reason_react_ppx.ml
+++ b/packages/server-reason-react-ppx/server_reason_react_ppx.ml
@@ -153,27 +153,13 @@ let make_prop ~is_optional ~prop attribute_name attribute_value =
         match ([%e attribute_value] : React.domRef option) with
         | None -> None
         | Some v -> Some (React.JSX.Ref v)]
-  | Attribute { type_ = DomProps.InnerHtml; _ }, false -> (
-      match attribute_value with
-      (* Even thought we dont have mel.obj in OCaml, we do in Reason.
-         We can extract the field __html and pass it to React.JSX.DangerouslyInnerHtml *)
-      | [%expr [%mel.obj { __html = [%e? inner] }]] ->
-          [%expr Some (React.JSX.DangerouslyInnerHtml [%e inner])]
-      | _ ->
-          raise_errorf ~loc
-            "jsx: unexpected expression found on dangerouslySetInnerHTML")
-  | Attribute { type_ = DomProps.InnerHtml; _ }, true -> (
-      match attribute_value with
-      (* Even thought we dont have mel.obj in OCaml, we do in Reason.
-         We can extract the field __html and pass it to React.JSX.DangerouslyInnerHtml *)
-      | [%expr [%mel.obj { __html = [%e? inner] }]] ->
-          [%expr
-            match [%e inner] with
-            | None -> None
-            | Some v -> Some (React.JSX.DangerouslyInnerHtml v)]
-      | _ ->
-          raise_errorf ~loc
-            "jsx: unexpected expression found on dangerouslySetInnerHTML")
+  | Attribute { type_ = DomProps.InnerHtml; _ }, false ->
+      [%expr Some (React.JSX.dangerouslyInnerHtml [%e attribute_value])]
+  | Attribute { type_ = DomProps.InnerHtml; _ }, true ->
+      [%expr
+        match [%e attribute_value] with
+        | None -> None
+        | Some v -> Some (React.JSX.dangerouslyInnerHtml v)]
   | Event { type_ = Mouse; jsxName }, false ->
       [%expr
         Some

--- a/packages/server-reason-react-ppx/test/dune
+++ b/packages/server-reason-react-ppx/test/dune
@@ -6,4 +6,4 @@
   server-reason-react.reactDom
   server-reason-react.js)
  (preprocess
-  (pps server-reason-react.ppx)))
+  (pps server-reason-react.ppx server-reason-react.melange_ppx)))

--- a/packages/server-reason-react-ppx/test/test.re
+++ b/packages/server-reason-react-ppx/test/test.re
@@ -53,7 +53,6 @@ let style_attribute = () => {
 
 let ref_attribute = () => {
   let divRef = React.useRef(Js.Nullable.null);
-
   let div = <div ref={React.Ref.domRef(divRef)} />;
   assert_string(ReactDOM.renderToStaticMarkup(div), {|<div></div>|});
 };


### PR DESCRIPTION
This PR implements: 
- The ppx
- Snapshot tests for the ppx
- Updated React/ReactDOM APIs (dangeourslySetInnerHTML), previously to this PR you would need to inline the mel.obj inside the ppx in order to read from the ppx code, now any object is valid.