### PR TITLE
Make useUrl return the provided serverUrl

### DIFF
--- a/packages/react/src/ReasonReactRouter.ml
+++ b/packages/react/src/ReasonReactRouter.ml
@@ -21,4 +21,6 @@ let url ?serverUrlString () =
 let dangerouslyGetInitialUrl = url
 let watchUrl _callback () = ()
 let unwatchUrl _watcherID = ()
-let useUrl ?serverUrl:_ () = url ()
+
+let useUrl ?(serverUrl : url option) () =
+  match serverUrl with Some serverUrl -> serverUrl | None -> url ()


### PR DESCRIPTION
Closes #123. This changes `useUrl` to mirror the behaviour of `reason-react` when the `serverUrl` is passed.

See https://github.com/reasonml/reason-react/blob/185d6972306b1009bd3fd3497510b346e757c4e3/src/ReasonReactRouter.re#L191-L197