### PR TITLE
Remove data-reactroot attr from ReactDom render_element

### DIFF
--- a/packages/reactDom/src/ReactDOM.ml
+++ b/packages/reactDom/src/ReactDOM.ml
@@ -60,9 +60,6 @@ let attributes_to_string attrs =
   | [] -> ""
   | rest -> " " ^ (rest |> String.concat " " |> String.trim)
 
-let react_root_attr_name = "data-reactroot"
-let data_react_root_attr = Printf.sprintf " %s=\"\"" react_root_attr_name
-
 type mode = String | Markup
 
 let render_to_string ~mode element =
@@ -74,9 +71,6 @@ let render_to_string ~mode element =
      <!-- --> between text nodes *)
   let previous_was_text_node = ref false in
   let rec render_element element =
-    let root_attribute =
-      match is_root.contents with true -> data_react_root_attr | false -> ""
-    in
     match element with
     | Empty -> ""
     | Provider children -> render_element children
@@ -88,11 +82,10 @@ let render_to_string ~mode element =
     | Lower_case_element { tag; attributes; _ }
       when Html.is_self_closing_tag tag ->
         is_root.contents <- false;
-        Printf.sprintf "<%s%s%s />" tag root_attribute
-          (attributes_to_string attributes)
+        Printf.sprintf "<%s%s />" tag (attributes_to_string attributes)
     | Lower_case_element { tag; attributes; children } ->
         is_root.contents <- false;
-        Printf.sprintf "<%s%s%s>%s</%s>" tag root_attribute
+        Printf.sprintf "<%s%s>%s</%s>" tag
           (attributes_to_string attributes)
           (children |> List.map render_element |> String.concat "")
           tag

--- a/packages/reactDom/test/test_renderToString.ml
+++ b/packages/reactDom/test/test_renderToString.ml
@@ -3,22 +3,18 @@ let assert_string left right =
 
 let react_root_one_element () =
   let div = React.createElement "div" [] [] in
-  assert_string (ReactDOM.renderToString div) "<div data-reactroot=\"\"></div>"
+  assert_string (ReactDOM.renderToString div) "<div></div>"
 
 let react_root_two_elements () =
   let div = React.createElement "div" [] [ React.createElement "span" [] [] ] in
-  assert_string
-    (ReactDOM.renderToString div)
-    "<div data-reactroot=\"\"><span></span></div>"
+  assert_string (ReactDOM.renderToString div) "<div><span></span></div>"
 
 let text_single_node () =
   let div =
     React.createElement "div" []
       [ React.createElement "span" [] [ React.string "Hello" ] ]
   in
-  assert_string
-    (ReactDOM.renderToString div)
-    "<div data-reactroot=\"\"><span>Hello</span></div>"
+  assert_string (ReactDOM.renderToString div) "<div><span>Hello</span></div>"
 
 let consecutives_text_nodes () =
   let div =
@@ -30,7 +26,7 @@ let consecutives_text_nodes () =
   in
   assert_string
     (ReactDOM.renderToString div)
-    "<div data-reactroot=\"\"><span>Hello<!-- -->Hello</span></div>"
+    "<div><span>Hello<!-- -->Hello</span></div>"
 
 let case title fn = Alcotest_lwt.test_case_sync title `Quick fn
 


### PR DESCRIPTION
###  Related Issue https://github.com/ml-in-barcelona/server-reason-react/issues/126

## Motivation

The `data-reactroot` was available before v18 when calling renderToString, but react removed it. 
It can be checked by seeing that renderToString doesn't return a string element with `data-reactroot` at this test:
https://github.com/facebook/react/blob/ed3c65caf042f75fe2fdc2a5e568a9624c6175fb/packages/react-dom/src/__tests__/ReactServerRendering-test.js#L4

The commit which removed that is this one:
https://github.com/facebook/react/commit/940f48b999a3131e77b2545bd7ae252ef27ae6d1

## What this PR does

- Remove `react_root_attr_name` and its follow dependencies;
- Update  renderToString tests.

## Checklist

- [x] Unit tests:

![image](https://github.com/ml-in-barcelona/server-reason-react/assets/35539594/a0e4b15b-10c0-4015-bec6-a2095ddb424c)
