### PR TITLE
browser_only: don't convert to runtime errors on identifiers or function application

### DIFF
--- a/packages/browser-ppx/ppx.ml
+++ b/packages/browser-ppx/ppx.ml
@@ -92,8 +92,8 @@ module Browser_only = struct
   let error_only_works_on ~loc =
     [%expr
       [%ocaml.error
-        "[browser_ppx] browser_only works on function definitions. If there's \
-         another case where it can be helpful, feel free to open an issue in \
+        "[browser_ppx] browser_only works on function definitions. For other \
+         cases, use switch%platform or feel free to open an issue in \
          https://github.com/ml-in-barcelona/server-reason-react."]]
 
   let remove_alert_browser_only ~loc =

--- a/packages/browser-ppx/ppx.ml
+++ b/packages/browser-ppx/ppx.ml
@@ -92,9 +92,9 @@ module Browser_only = struct
   let error_only_works_on ~loc =
     [%expr
       [%ocaml.error
-        "[browser_ppx] browser_only works on function definitions or values. \
-         If there's another case where it can be helpful, feel free to open an \
-         issue in https://github.com/ml-in-barcelona/server-reason-react."]]
+        "[browser_ppx] browser_only works on function definitions. If there's \
+         another case where it can be helpful, feel free to open an issue in \
+         https://github.com/ml-in-barcelona/server-reason-react."]]
 
   let remove_alert_browser_only ~loc =
     Builder.attribute ~loc ~name:{ txt = "alert"; loc }

--- a/packages/browser-ppx/ppx.ml
+++ b/packages/browser-ppx/ppx.ml
@@ -135,14 +135,6 @@ module Browser_only = struct
             in
             let vb = Builder.value_binding ~loc ~pat:pattern ~expr in
             { vb with pvb_attributes = [ remove_alert_browser_only ~loc ] }
-        | Pexp_ident { txt = longident; loc } ->
-            let stringified = Ppxlib.Longident.name longident in
-            let message = Builder.estring ~loc stringified in
-            let vb =
-              Builder.value_binding ~loc ~pat:pattern
-                ~expr:[%expr Runtime.fail_impossible_action_in_ssr [%e message]]
-            in
-            { vb with pvb_attributes = [ remove_alert_browser_only ~loc ] }
         | _ ->
             Builder.value_binding ~loc ~pat:pattern
               ~expr:(error_only_works_on ~loc))

--- a/packages/browser-ppx/ppx.ml
+++ b/packages/browser-ppx/ppx.ml
@@ -147,12 +147,6 @@ module Browser_only = struct
     | Js -> payload
     | Native -> (
         match payload.pexp_desc with
-        | Pexp_apply (expression, _) ->
-            let stringified =
-              Ppxlib.Pprintast.string_of_expression expression
-            in
-            let message = Builder.estring ~loc stringified in
-            [%expr Runtime.fail_impossible_action_in_ssr [%e message]]
         | Pexp_constraint
             ( {
                 pexp_desc =

--- a/packages/browser-ppx/tests/pexp_apply.t
+++ b/packages/browser-ppx/tests/pexp_apply.t
@@ -20,15 +20,15 @@ Without -js flag, the compilation to native errors out indicating that a functio
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl
   let pstr_value_binding =
     [%ocaml.error
-      "[browser_ppx] browser_only works on function definitions. If there's \
-       another case where it can be helpful, feel free to open an issue in \
+      "[browser_ppx] browser_only works on function definitions. For other \
+       cases, use switch%platform or feel free to open an issue in \
        https://github.com/ml-in-barcelona/server-reason-react."]
   
   let make () =
     let pstr_value_binding_2 =
       [%ocaml.error
-        "[browser_ppx] browser_only works on function definitions. If there's \
-         another case where it can be helpful, feel free to open an issue in \
+        "[browser_ppx] browser_only works on function definitions. For other \
+         cases, use switch%platform or feel free to open an issue in \
          https://github.com/ml-in-barcelona/server-reason-react."]
     in
     ()

--- a/packages/browser-ppx/tests/pexp_apply.t
+++ b/packages/browser-ppx/tests/pexp_apply.t
@@ -14,18 +14,21 @@ With -js flag everything keeps as it is and browser_only extension disappears
   let make () =
     let pstr_value_binding_2 = Webapi.Dom.getElementById "foo" in
     ()
+
+Without -js flag, the compilation to native errors out indicating that a function must be used
+
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl
   let pstr_value_binding =
     [%ocaml.error
-      "[browser_ppx] browser_only works on function definitions or values. If \
-       there's another case where it can be helpful, feel free to open an issue \
-       in https://github.com/ml-in-barcelona/server-reason-react."]
+      "[browser_ppx] browser_only works on function definitions. If there's \
+       another case where it can be helpful, feel free to open an issue in \
+       https://github.com/ml-in-barcelona/server-reason-react."]
   
   let make () =
     let pstr_value_binding_2 =
       [%ocaml.error
-        "[browser_ppx] browser_only works on function definitions or values. If \
-         there's another case where it can be helpful, feel free to open an \
-         issue in https://github.com/ml-in-barcelona/server-reason-react."]
+        "[browser_ppx] browser_only works on function definitions. If there's \
+         another case where it can be helpful, feel free to open an issue in \
+         https://github.com/ml-in-barcelona/server-reason-react."]
     in
     ()

--- a/packages/browser-ppx/tests/pexp_apply.t
+++ b/packages/browser-ppx/tests/pexp_apply.t
@@ -16,7 +16,10 @@ With -js flag everything keeps as it is and browser_only extension disappears
     ()
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl
   let pstr_value_binding =
-    Runtime.fail_impossible_action_in_ssr "Webapi.Dom.getElementById"
+    [%ocaml.error
+      "[browser_ppx] browser_only works on function definitions or values. If \
+       there's another case where it can be helpful, feel free to open an issue \
+       in https://github.com/ml-in-barcelona/server-reason-react."]
   
   let make () =
     let pstr_value_binding_2 =

--- a/packages/browser-ppx/tests/pexp_ident.t
+++ b/packages/browser-ppx/tests/pexp_ident.t
@@ -11,14 +11,14 @@ With -js flag everything keeps as it is and browser_only extension disappears
     let pexp_ident = Webapi__Dom__Element.asHtmlElement in
     ()
 
-Without -js flag, the compilation to native replaces the expression with `Runtime.fail_impossible_action_in_ssr`
+Without -js flag, the compilation to native errors out indicating that a function must be used
 
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl
   let make () =
     let pexp_ident =
       [%ocaml.error
-        "[browser_ppx] browser_only works on function definitions or values. If \
-         there's another case where it can be helpful, feel free to open an \
-         issue in https://github.com/ml-in-barcelona/server-reason-react."]
+        "[browser_ppx] browser_only works on function definitions. If there's \
+         another case where it can be helpful, feel free to open an issue in \
+         https://github.com/ml-in-barcelona/server-reason-react."]
     in
     ()

--- a/packages/browser-ppx/tests/pexp_ident.t
+++ b/packages/browser-ppx/tests/pexp_ident.t
@@ -16,7 +16,9 @@ Without -js flag, the compilation to native replaces the expression with `Runtim
   $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl
   let make () =
     let pexp_ident =
-      Runtime.fail_impossible_action_in_ssr "Webapi__Dom__Element.asHtmlElement"
-        [@@alert "-browser_only"]
+      [%ocaml.error
+        "[browser_ppx] browser_only works on function definitions or values. If \
+         there's another case where it can be helpful, feel free to open an \
+         issue in https://github.com/ml-in-barcelona/server-reason-react."]
     in
     ()

--- a/packages/browser-ppx/tests/pexp_ident.t
+++ b/packages/browser-ppx/tests/pexp_ident.t
@@ -17,8 +17,8 @@ Without -js flag, the compilation to native errors out indicating that a functio
   let make () =
     let pexp_ident =
       [%ocaml.error
-        "[browser_ppx] browser_only works on function definitions. If there's \
-         another case where it can be helpful, feel free to open an issue in \
+        "[browser_ppx] browser_only works on function definitions. For other \
+         cases, use switch%platform or feel free to open an issue in \
          https://github.com/ml-in-barcelona/server-reason-react."]
     in
     ()


### PR DESCRIPTION
I had a case where I used `browser_only` in some event handler using a curried function, e.g.:

```re
onKeyDown=[%browser_only
  onKeyDown(~foo)
]
```

This code converted to plain `Runtime.fail_impossible_action_in_ssr`, crashing the server application at runtime.

This PR removes some of the cases where `browser_only` can be used:
- identifiers
- function application (pexp_apply)

so this extension can only be used to convert function definitions.

Users can still use `switch%platform` for identifiers and function applications, which prevents running on footguns like the one mentioned above.