### PR TITLE
Fix playsinline misswriting for videoHTMLAttributes

### DIFF
--- a/packages/react/src/DomProps.ml
+++ b/packages/react/src/DomProps.ml
@@ -1074,7 +1074,7 @@ let videoHTMLAttributes =
     Attribute { name = "controls"; jsxName = "controls"; type_ = Bool };
     Attribute { name = "crossorigin"; jsxName = "crossOrigin"; type_ = String };
     Attribute { name = "height"; jsxName = "height"; type_ = String (* number | *) };
-    Attribute { name = "playsInline"; jsxName = "playsinline"; type_ = Bool };
+    Attribute { name = "playsinline"; jsxName = "playsInline"; type_ = Bool };
 
     Attribute { name = "loop"; jsxName = "loop"; type_ = Bool };
     Attribute { name = "poster"; jsxName = "poster"; type_ = String };


### PR DESCRIPTION
## Description

playsInline attributes `name` and `jsxName` is miswrite; they should be changed between each other

```ocaml
    Attribute { name = "playsinline"; jsxName = "playsInline"; type_ = Bool };
```