### PR TITLE
Add missing attr to videoHTMLAttributes

### DIFF
--- a/packages/react/src/DomProps.ml
+++ b/packages/react/src/DomProps.ml
@@ -1077,6 +1077,8 @@ let videoHTMLAttributes =
     Attribute { name = "playsinline"; jsxName = "playsInline"; type_ = Bool };
 
     Attribute { name = "loop"; jsxName = "loop"; type_ = Bool };
+    Attribute { name = "muted"; jsxName = "muted"; type_ = Bool };
+    Attribute { name = "preload"; jsxName = "preload"; type_ = String };
     Attribute { name = "poster"; jsxName = "poster"; type_ = String };
     Attribute { name = "width"; jsxName = "width"; type_ = String (* number | *) };
     Attribute { name = "disablepictureinpicture"; jsxName = "disablePictureInPicture"; type_ = Bool };


### PR DESCRIPTION
## Description

Add missing attributes on videoHTMLAttributes: [muted](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#muted) and [preload](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#preload)