### PR TITLE
Refactor ReactDOM to use Html (which uses Buffers, not Printf)

### DIFF
--- a/packages/html/Html.ml
+++ b/packages/html/Html.ml
@@ -20,3 +20,124 @@ let is_self_closing_tag = function
   | "link" (* | "menuitem" *) | "meta" | "param" | "source" | "track" | "wbr" ->
       true
   | _ -> false
+
+(* This function is borrowed from https://github.com/dbuenzli/htmlit/blob/62d8f21a9233791a5440311beac02a4627c3a7eb/src/htmlit.ml#L10-L28 *)
+let escape_and_add out str =
+  let add = Buffer.add_string in
+  let len = String.length str in
+  let max_index = len - 1 in
+  let flush out start index =
+    if start < len then Buffer.add_substring out str start (index - start)
+  in
+  let rec loop start index =
+    if index > max_index then flush out start index
+    else
+      let next = index + 1 in
+      match String.get str index with
+      | '&' ->
+          flush out start index;
+          add out "&amp;";
+          loop next next
+      | '<' ->
+          flush out start index;
+          add out "&lt;";
+          loop next next
+      | '>' ->
+          flush out start index;
+          add out "&gt;";
+          loop next next
+      | '\'' ->
+          flush out start index;
+          add out "&apos;";
+          loop next next
+      | '\"' ->
+          flush out start index;
+          add out "&quot;";
+          loop next next
+      | _ -> loop start next
+  in
+  loop 0 0
+
+type attribute =
+  string * [ `Bool of bool | `Int of int | `Float of float | `String of string ]
+
+let write_attribute out (attr : attribute) =
+  let write_name_value name value =
+    Buffer.add_char out ' ';
+    Buffer.add_string out name;
+    Buffer.add_string out "=\"";
+    escape_and_add out value;
+    Buffer.add_char out '"'
+  in
+  match attr with
+  | _name, `Bool false ->
+      (* false attributes don't get rendered *)
+      ()
+  | name, `Bool true ->
+      (* true attributes render solely the attribute name *)
+      Buffer.add_char out ' ';
+      Buffer.add_string out name
+  | name, `String value -> write_name_value name value
+  | name, `Int value -> write_name_value name (string_of_int value)
+  | name, `Float value -> write_name_value name (string_of_float value)
+
+type element =
+  | Null
+  | String of string
+  | Raw of string (* text without encoding *)
+  | Node of {
+      tag : string;
+      attributes : attribute list;
+      children : element list;
+    }
+  | List of (string * element list)
+
+let string txt = String txt
+let raw txt = Raw txt
+let null = Null
+let int i = String (Int.to_string i)
+let float f = String (Float.to_string f)
+let list ?(separator = "") arr = List (separator, arr)
+let fragment arr = List arr
+let node tag attributes children = Node { tag; attributes; children }
+
+let render element =
+  let out = Buffer.create 1024 in
+  let rec write element =
+    match element with
+    | Null -> ()
+    | String text -> escape_and_add out text
+    | Raw text -> Buffer.add_string out text
+    | Node { tag; attributes; _ } when is_self_closing_tag tag ->
+        Buffer.add_char out '<';
+        Buffer.add_string out tag;
+        List.iter (write_attribute out) attributes;
+        Buffer.add_string out " />"
+    | Node { tag; attributes; children } ->
+        if tag = "html" then Buffer.add_string out "<!DOCTYPE html>";
+        Buffer.add_char out '<';
+        Buffer.add_string out tag;
+        List.iter (write_attribute out) attributes;
+        Buffer.add_char out '>';
+        List.iter write children;
+        Buffer.add_string out "</";
+        Buffer.add_string out tag;
+        Buffer.add_char out '>'
+    | List (separator, list) ->
+        let rec iter list =
+          match list with
+          | [] -> ()
+          | [ one ] -> write one
+          | [ first; second ] ->
+              write first;
+              Buffer.add_string out separator;
+              write second
+          | first :: rest ->
+              write first;
+              Buffer.add_string out separator;
+              iter rest
+        in
+        iter list
+  in
+  write element;
+  Buffer.contents out

--- a/packages/reactDom/src/ReactDOMStyle.ml
+++ b/packages/reactDom/src/ReactDOMStyle.ml
@@ -349,9 +349,9 @@ let make
   ?(rubyMerge : string option)
   ?(rubyPosition : string option)
   () =
-  (* 
+  (*
      The order of addition matters since it will need to be the same order as
-  the JS object defined in https://github.com/reasonml/reason-react/blob/3327dc214905c4b2863b19807aaac375633645cf/src/dOMStyle.re 
+  the JS object defined in https://github.com/reasonml/reason-react/blob/3327dc214905c4b2863b19807aaac375633645cf/src/dOMStyle.re
 
   The following shell script can be run from the reason-react repository to generate the calls to "add" below:
 

--- a/packages/reactDom/test/test_renderToLwtStream.ml
+++ b/packages/reactDom/test/test_renderToLwtStream.ml
@@ -32,24 +32,37 @@ let test_silly_stream _switch () =
   push None;
   assert_stream stream [ "first"; "secondo"; "trienio" ]
 
-let react_use_without_suspense _switch () =
-  (* TODO: assert exception *)
-  (* We clean the cache so we can re-use the same promise *)
-  Sleep.destroy ();
-  let delay = 0.1 in
-  let app =
-    React.Upper_case_component
-      (fun () ->
-        let () = React.Experimental.use (Sleep.delay delay) in
-        React.createElement "div" []
-          [
-            React.createElement "span" []
-              [ React.string "Hello "; React.float delay ];
-          ])
-  in
-  let%lwt stream, _abort = ReactDOM.renderToLwtStream app in
-  assert_stream stream [ "<div><span>Hello 0.1</span></div>" ]
+(* let lwt_check_raises f =
+     let open Lwt.Infix in
+     Lwt.catch
+       (fun () -> f () >|= fun () -> `Ok)
+       (function e -> Lwt.return @@ `Error e)
+     >|= function
+     | `Ok -> Alcotest.fail "No exception was thrown"
+     | `Error (React.Suspend _) ->
+         Alcotest.(check pass) "Expect suspense to raise" () ()
+     | `Error exn -> Lwt.reraise exn
 
+   let react_use_without_suspense _switch () =
+     (* We clean the cache so we can re-use the same promise *)
+     Sleep.destroy ();
+     let delay = 0.1 in
+     let app =
+       React.Upper_case_component
+         (fun () ->
+           let () = React.Experimental.use (Sleep.delay delay) in
+           React.createElement "div" []
+             [
+               React.createElement "span" []
+                 [ React.string "Hello "; React.float delay ];
+             ])
+     in
+     let raises () =
+       let%lwt stream, _abort = ReactDOM.renderToLwtStream app in
+       assert_stream stream [ "<div><span>Hello 0.1</span></div>" ]
+     in
+     lwt_check_raises raises
+*)
 let suspense_without_promise _switch () =
   let hi =
     React.Upper_case_component
@@ -72,7 +85,7 @@ let suspense_with_always_throwing _switch () =
   in
   let%lwt stream, _abort = ReactDOM.renderToLwtStream app in
   assert_stream stream
-    [ "<!--$?--><template id='B:0'></template>Loading...<!--/$-->" ]
+    [ "<!--$?--><template id=\"B:0\"></template>Loading...<!--/$-->" ]
 
 let react_use_with_suspense _switch () =
   Sleep.destroy ();
@@ -93,8 +106,8 @@ let react_use_with_suspense _switch () =
   let%lwt stream, _abort = ReactDOM.renderToLwtStream app in
   assert_stream stream
     [
-      "<!--$?--><template id='B:0'></template>Loading...<!--/$-->";
-      "<div hidden id='S:0'><div><span>Hello 0.5</span></div></div>";
+      "<!--$?--><template id=\"B:0\"></template>Loading...<!--/$-->";
+      "<div hidden id=\"S:0\"><div><span>Hello 0.5</span></div></div>";
       "<script>function \
        $RC(a,b){a=document.getElementById(a);b=document.getElementById(b);b.parentNode.removeChild(b);if(a){a=a.previousSibling;var \
        f=a.parentNode,c=a.nextSibling,e=0;do{if(c&&8===c.nodeType){var \

--- a/packages/reactDom/test/test_renderToStaticMarkup.ml
+++ b/packages/reactDom/test/test_renderToStaticMarkup.ml
@@ -124,7 +124,7 @@ let encode_attributes () =
   in
   assert_string
     (ReactDOM.renderToStaticMarkup component)
-    "<div about=\"&#x27; &lt;\" data-user-path=\"what/the/path\">&amp; \
+    "<div about=\"&apos; &lt;\" data-user-path=\"what/the/path\">&amp; \
      &quot;</div>"
 
 let dangerouslySetInnerHtml () =
@@ -231,17 +231,6 @@ let className_2 () =
   assert_string
     (ReactDOM.renderToStaticMarkup component)
     "<div class=\"flex xs:justify-center overflow-hidden\"></div>"
-
-let _onclick_render_as_string () =
-  let component =
-    React.createElement "div"
-      [ React.JSX.Event ("_onclick", Inline "$(this).hide()") ]
-      []
-  in
-
-  assert_string
-    (ReactDOM.renderToStaticMarkup component)
-    "<div onclick=\"$(this).hide()\"></div>"
 
 let render_with_doc_type () =
   let div =
@@ -352,13 +341,15 @@ let async_component () =
       (fun () ->
         Lwt.return (React.createElement "span" [] [ React.string "yow" ]))
   in
-  Alcotest.check_raises "wat"
+  let raises () =
+    let _ = ReactDOM.renderToStaticMarkup app in
+    ()
+  in
+  Alcotest.check_raises "Expected failure"
     (Failure
        "Asyncronous components can't be rendered to static markup, since \
         rendering is syncronous. Please use `renderToLwtStream` instead.")
-    (fun () ->
-      let _ : string = ReactDOM.renderToStaticMarkup app in
-      ())
+    raises
 
 let tests =
   ( "renderToStaticMarkup",
@@ -388,7 +379,6 @@ let tests =
       test "use_callback" use_callback;
       test "inner_html" inner_html;
       test "event" event;
-      test "_onclick_render_as_string" _onclick_render_as_string;
       test "render_with_doc_type" render_with_doc_type;
       test "render_svg" render_svg;
       test "ref_as_prop_works" ref_as_prop_works;

--- a/packages/server-reason-react-ppx/test/test.re
+++ b/packages/server-reason-react-ppx/test/test.re
@@ -1,3 +1,5 @@
+let test = (title, fn) => Alcotest.test_case(title, `Quick, fn);
+
 let assert_string = (left, right) => {
   Alcotest.check(Alcotest.string, "should be equal", right, left);
 };
@@ -196,15 +198,6 @@ let onClick_empty = () => {
   assert_string(ReactDOM.renderToStaticMarkup(div), {|<div></div>|});
 };
 
-let onclick_inline_string = () => {
-  let onClick = "console.log('clicked')";
-  let div = <div _onclick=onClick />;
-  assert_string(
-    ReactDOM.renderToStaticMarkup(div),
-    {|<div onclick="console.log('clicked')"></div>|},
-  );
-};
-
 let svg_1 = () => {
   assert_string(
     ReactDOM.renderToStaticMarkup(
@@ -326,11 +319,6 @@ let children_multiple_elements = () => {
   );
 };
 
-let case = (title, fn) => Alcotest.test_case(title, `Quick, fn);
-
-let assert_string = (left, right) =>
-  Alcotest.check(Alcotest.string, "should be equal", right, left);
-
 module Text = {
   module Tag = {
     type t =
@@ -399,42 +387,41 @@ let _ =
       (
         "renderToStaticMarkup",
         [
-          case("div", tag),
-          case("div_empty_attr", empty_attribute),
-          case("div_bool_attr", bool_attribute),
-          case("input_bool_attrs", bool_attributes),
-          case("p_inner_html", innerhtml),
-          case("div_int_attr", int_attribute),
-          case("svg_1", svg_1),
-          case("svg_2", svg_2),
-          case("booleanish_props_with_ppx", booleanish_props_with_ppx),
-          case("booleanish_props_without_ppx", booleanish_props_without_ppx),
-          case("style_attr", style_attribute),
-          case("div_ref_attr", ref_attribute),
-          case("link_as_attr", link_as_attribute),
-          case("inner_html_attr", innerhtml_attribute),
-          case("p_inner_html", innerhtml_attribute_complex),
-          case("int_opt_attr_some", int_opt_attribute_some),
-          case("int_opt_attr_none", int_opt_attribute_none),
-          case("string_opt_attr_some", string_opt_attribute_some),
-          case("string_opt_attr_none", string_opt_attribute_none),
-          case("bool_opt_attr_some", bool_opt_attribute_some),
-          case("bool_opt_attr_none", bool_opt_attribute_none),
-          case("style_opt_attr_some", style_opt_attribute_some),
-          case("style_opt_attr_none", style_opt_attribute_none),
-          case("ref_opt_attr_some", ref_opt_attribute_some),
-          case("ref_opt_attr_none", ref_opt_attribute_none),
-          case("test_fragment", fragment),
-          case("test_fragment_with_key", fragment_with_key),
-          case("test_children_uppercase", children_uppercase),
-          case("test_children_lowercase", children_lowercase),
-          case("event_onClick", onClick_empty),
-          case("event_onclick_inline_string", onclick_inline_string),
-          case("children_one_element", children_one_element),
-          case("children_multiple_elements", children_multiple_elements),
-          case("createElementVariadic", create_element_variadic),
-          case("aria_props", aria_props),
-          case("optional_prop", optional_prop),
+          test("div", tag),
+          test("div_empty_attr", empty_attribute),
+          test("div_bool_attr", bool_attribute),
+          test("input_bool_attrs", bool_attributes),
+          test("p_inner_html", innerhtml),
+          test("div_int_attr", int_attribute),
+          test("svg_1", svg_1),
+          test("svg_2", svg_2),
+          test("booleanish_props_with_ppx", booleanish_props_with_ppx),
+          test("booleanish_props_without_ppx", booleanish_props_without_ppx),
+          test("style_attr", style_attribute),
+          test("div_ref_attr", ref_attribute),
+          test("link_as_attr", link_as_attribute),
+          test("inner_html_attr", innerhtml_attribute),
+          test("p_inner_html", innerhtml_attribute_complex),
+          test("int_opt_attr_some", int_opt_attribute_some),
+          test("int_opt_attr_none", int_opt_attribute_none),
+          test("string_opt_attr_some", string_opt_attribute_some),
+          test("string_opt_attr_none", string_opt_attribute_none),
+          test("bool_opt_attr_some", bool_opt_attribute_some),
+          test("bool_opt_attr_none", bool_opt_attribute_none),
+          test("style_opt_attr_some", style_opt_attribute_some),
+          test("style_opt_attr_none", style_opt_attribute_none),
+          test("ref_opt_attr_some", ref_opt_attribute_some),
+          test("ref_opt_attr_none", ref_opt_attribute_none),
+          test("test_fragment", fragment),
+          test("test_fragment_with_key", fragment_with_key),
+          test("test_children_uppercase", children_uppercase),
+          test("test_children_lowercase", children_lowercase),
+          test("event_onClick", onClick_empty),
+          test("children_one_element", children_one_element),
+          test("children_multiple_elements", children_multiple_elements),
+          test("createElementVariadic", create_element_variadic),
+          test("aria_props", aria_props),
+          test("optional_prop", optional_prop),
         ],
       ),
     ],


### PR DESCRIPTION
- Bring html_of_jsx's JSX module here and factor it 
- Remove "_onclick" hack since it's not used anymore
- Use Html module in renderToString* and renderToLwtStream, making it probably x10 faster if not more. There are a tiny bit of allocations that we might be able to remove, but so far I have cleanup up most of them (for example Attribute.omit unsure if it allocates that unused string?)