### PR TITLE
Add traverse to handle nested module with platform anotation

### DIFF
--- a/packages/browser-ppx/ppx.ml
+++ b/packages/browser-ppx/ppx.ml
@@ -520,8 +520,7 @@ module Preprocess = struct
         | { pstr_desc = Pstr_attribute attr; _ } :: rest
           when is_platform_tag attr.attr_name.txt ->
             if eval_attr attr = `keep then rest else []
-        | str ->
-            List.filter_map apply_config_on_structure_item (super#structure str)
+        | str -> List.filter_map apply_config_on_structure_item str
 
       method! signature sigi =
         let sigi = super#signature sigi in
@@ -529,9 +528,7 @@ module Preprocess = struct
         | { psig_desc = Psig_attribute attr; _ } :: rest
           when is_platform_tag attr.attr_name.txt ->
             if eval_attr attr = `keep then rest else []
-        | _ ->
-            List.filter_map apply_config_on_signature_item
-              (super#signature sigi)
+        | _ -> List.filter_map apply_config_on_signature_item sigi
     end
 end
 

--- a/packages/browser-ppx/ppx.ml
+++ b/packages/browser-ppx/ppx.ml
@@ -510,25 +510,28 @@ module Preprocess = struct
         else None
     | Psig_extension _ | Psig_attribute _ -> Some sigi
 
-  let preprocess_impl str =
-    match str with
-    | { pstr_desc = Pstr_attribute attr; _ } :: rest
-      when is_platform_tag attr.attr_name.txt ->
-        if eval_attr attr = `keep then rest else []
-    | _ -> List.filter_map apply_config_on_structure_item str
-
-  let preprocess_intf sigi =
-    match sigi with
-    | { psig_desc = Psig_attribute attr; _ } :: rest
-      when is_platform_tag attr.attr_name.txt ->
-        if eval_attr attr = `keep then rest else []
-    | _ -> List.filter_map apply_config_on_signature_item sigi
-
   let traverse =
     object (_ : Ast_traverse.map)
       inherit Ast_traverse.map as super
-      method! structure expr = preprocess_impl (super#structure expr)
-      method! signature sigi = preprocess_intf (super#signature sigi)
+
+      method! structure str =
+        let str = super#structure str in
+        match str with
+        | { pstr_desc = Pstr_attribute attr; _ } :: rest
+          when is_platform_tag attr.attr_name.txt ->
+            if eval_attr attr = `keep then rest else []
+        | str ->
+            List.filter_map apply_config_on_structure_item (super#structure str)
+
+      method! signature sigi =
+        let sigi = super#signature sigi in
+        match sigi with
+        | { psig_desc = Psig_attribute attr; _ } :: rest
+          when is_platform_tag attr.attr_name.txt ->
+            if eval_attr attr = `keep then rest else []
+        | _ ->
+            List.filter_map apply_config_on_signature_item
+              (super#signature sigi)
     end
 end
 

--- a/packages/browser-ppx/tests/preprocess.t
+++ b/packages/browser-ppx/tests/preprocess.t
@@ -1,3 +1,41 @@
+Nested
+
+  $ cat > input.ml << EOF
+  >  module X = struct
+  >    include struct
+  >      type t = Js.Json.t
+  >      let a = 2 + 2
+  >    end [@@platform js]
+  >  
+  >    include struct
+  >      type t = Js.Json.t
+  >      let a = 4 + 4
+  >    end [@@platform native]
+  >  end
+  > EOF
+
+With -js flag it picks the block with `[@@platform js]`
+
+  $ ./standalone.exe -impl input.ml -js | ocamlformat - --enable-outside-detected-project --impl
+  module X = struct
+    include struct
+      type t = Js.Json.t
+  
+      let a = 2 + 2
+    end [@@platform js]
+  end
+
+Without -js flag, it picks the block with `[@@platform native]`
+
+  $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl
+  module X = struct
+    include struct
+      type t = Js.Json.t
+  
+      let a = 4 + 4
+    end [@@platform native]
+  end
+
 Pstr_include
 
   $ cat > input.ml << EOF
@@ -138,9 +176,7 @@ Pstr_eval (doesn't work)
   > EOF
 
   $ ./standalone.exe -impl input_primitive.ml | ocamlformat - --enable-outside-detected-project --impl
-  include struct
-    2 [@@platform js]
-  end
+  include struct end
   
   include struct
     3 [@@platform native]
@@ -151,9 +187,7 @@ Pstr_eval (doesn't work)
     2 [@@platform js]
   end
   
-  include struct
-    3 [@@platform native]
-  end
+  include struct end
 
 Pstr_type
 


### PR DESCRIPTION
## Description

The nested module does not work with the platform attribute.

```ocaml
module X = struct
  include struct
    type t = Js.Json.t
    let a = 2 + 2
  end [@@platform js]
   
  include struct
    type t = string
    let a = 4 + 4
  end [@@platform native]
end

(* With -js flag output: *)
  module X = struct
    include struct
      type t = Js.Json.t
  
      let a = 2 + 2
    end [@@platform js]
  
    include struct
      type t = string
  
      let a = 4 + 4
    end [@@platform native]
  end

(* With no flag output: *)
  module X = struct
    include struct
      type t = Js.Json.t
  
      let a = 2 + 2
    end [@@platform js]
  
    include struct
      type t = string
  
      let a = 4 + 4
    end [@@platform native]
  end
```

As you can see, it does not work well if we want nested modules with the platform attribute.

## How

We were using a standard function to analyze the TopLevel structure items when we could use a Traverse map that, according to the PPXLib doc:

> A traversal is a recursive function that will be called on a value and recursively on all its sub-values, combining the result in a certain way.

Using traverse, it looks for all structures recursively, and the output of the description sample would be:

```ocaml
(* With -js flag output: *)
module X = struct
  include struct
    type t = Js.Json.t
    let a = 2 + 2
  end [@@platform js]
end

(* Without -js flag output: *)
module X = struct
  include struct
    type t = string
    let a = 4 + 4
  end [@@platform native]
end
```

@davesnx I know that we talked about it, and you said that maybe Global Transformation was not the way, but I was studying more about `prepocess_impl` and `impl`, and found the `Ast_traverse`, which worked on it. Does it make sense for now?