### PR TITLE
Add native code to Js.String.split

### DIFF
--- a/packages/melange.js/Js.ml
+++ b/packages/melange.js/Js.ml
@@ -758,28 +758,25 @@ end = struct
     else Stdlib.String.sub str start_idx (end_idx - start_idx)
 
   let split ?sep ?limit str =
-    match%platform () with
-    | Client -> Js.String.split ~sep ~limit str
-    | Server -> (
-        let sep = Option.value sep ~default:str in
-        let regexp = Str.regexp_string sep in
-        let items =
-          match
-            ( Str.string_match regexp str 0,
-              Str.string_match regexp str (String.length str - String.length sep),
-              sep <> "" )
-          with
-          | true, true, true -> ("" :: Str.split regexp str) @ [ "" ]
-          | true, false, true -> "" :: Str.split regexp str
-          | false, true, true -> Str.split regexp str @ [ "" ]
-          | _ -> Str.split regexp str
-        in
-        let items = items |> Stdlib.Array.of_list in
-        let limit = Option.value limit ~default:(Stdlib.Array.length items) in
-        match limit with
-        | limit when limit >= 0 && limit < Stdlib.Array.length items ->
-            Stdlib.Array.sub items 0 limit
-        | _ -> items)
+    let sep = Option.value sep ~default:str in
+    let regexp = Str.regexp_string sep in
+    let items =
+      match
+        ( Str.string_match regexp str 0,
+          Str.string_match regexp str (String.length str - String.length sep),
+          sep <> "" )
+      with
+      | true, true, true -> ("" :: Str.split regexp str) @ [ "" ]
+      | true, false, true -> "" :: Str.split regexp str
+      | false, true, true -> Str.split regexp str @ [ "" ]
+      | _ -> Str.split regexp str
+    in
+    let items = items |> Stdlib.Array.of_list in
+    let limit = Option.value limit ~default:(Stdlib.Array.length items) in
+    match limit with
+    | limit when limit >= 0 && limit < Stdlib.Array.length items ->
+        Stdlib.Array.sub items 0 limit
+    | _ -> items
 
   let splitByRe ~regexp ?limit str =
     let rev_array arr =

--- a/packages/melange.js/Js.ml
+++ b/packages/melange.js/Js.ml
@@ -760,15 +760,19 @@ end = struct
   let split ?sep ?limit str =
     let sep = Option.value sep ~default:str in
     let regexp = Str.regexp_string sep in
+    let str_start_with_sep = Stdlib.String.starts_with ~prefix:sep str in
+    let str_end_with_sep = Stdlib.String.ends_with ~suffix:sep str in
     let items =
-      match
-        ( Str.string_match regexp str 0,
-          Str.string_match regexp str (String.length str - String.length sep),
-          sep <> "" )
-      with
+      (* Melange (JS) has some specific cases for splitting strings: *)
+      (* https://melange.re/unstable/playground/?language=OCaml&code=SnMubG9nKEpzLlN0cmluZy5zcGxpdCB%2Bc2VwOiJzdGFydCIgInN0YXJ0Lm9jYW1sLnJlYXNvbi5yZWFjdCIpOwpKcy5sb2coSnMuU3RyaW5nLnNwbGl0IH5zZXA6ImVuZCIgIm9jYW1sLnJlYXNvbi5yZWFjdC5lbmQiKTsKSnMubG9nKEpzLlN0cmluZy5zcGxpdCB%2Bc2VwOiJib3RoIiAiYm90aC5vY2FtbC5yZWFzb24ucmVhY3QuYm90aCIpOw%3D%3D&live=off *)
+      match (str_start_with_sep, str_end_with_sep, sep <> "") with
+      (* If the string starts and ends with the separator, we need to add an empty string at the beginning and the end *)
       | true, true, true -> ("" :: Str.split regexp str) @ [ "" ]
+      (* If the string starts with the separator, we need to add an empty string at the beginning *)
       | true, false, true -> "" :: Str.split regexp str
+      (* If the string ends with the separator, we need to add an empty string at the end *)
       | false, true, true -> Str.split regexp str @ [ "" ]
+      (* If the string doesn't start or end with the separator, we just split it *)
       | _ -> Str.split regexp str
     in
     let items = items |> Stdlib.Array.of_list in

--- a/packages/melange.js/Js.ml
+++ b/packages/melange.js/Js.ml
@@ -757,7 +757,29 @@ end = struct
     if start_idx >= end_idx then ""
     else Stdlib.String.sub str start_idx (end_idx - start_idx)
 
-  let split ?sep ?limit _str = notImplemented "Js.String" "split"
+  let split ?sep ?limit str =
+    match%platform () with
+    | Client -> Js.String.split ~sep ~limit str
+    | Server -> (
+        let sep = Option.value sep ~default:str in
+        let regexp = Str.regexp_string sep in
+        let items =
+          match
+            ( Str.string_match regexp str 0,
+              Str.string_match regexp str (String.length str - String.length sep),
+              sep <> "" )
+          with
+          | true, true, true -> ("" :: Str.split regexp str) @ [ "" ]
+          | true, false, true -> "" :: Str.split regexp str
+          | false, true, true -> Str.split regexp str @ [ "" ]
+          | _ -> Str.split regexp str
+        in
+        let items = items |> Stdlib.Array.of_list in
+        let limit = Option.value limit ~default:(Stdlib.Array.length items) in
+        match limit with
+        | limit when limit >= 0 && limit < Stdlib.Array.length items ->
+            Stdlib.Array.sub items 0 limit
+        | _ -> items)
 
   let splitByRe ~regexp ?limit str =
     let rev_array arr =

--- a/packages/melange.js/Js.ml
+++ b/packages/melange.js/Js.ml
@@ -760,22 +760,11 @@ end = struct
   let split ?sep ?limit str =
     let sep = Option.value sep ~default:str in
     let regexp = Str.regexp_string sep in
-    let str_start_with_sep = Stdlib.String.starts_with ~prefix:sep str in
-    let str_end_with_sep = Stdlib.String.ends_with ~suffix:sep str in
-    let items =
-      (* Melange (JS) has some specific cases for splitting strings: *)
-      (* https://melange.re/unstable/playground/?language=OCaml&code=SnMubG9nKEpzLlN0cmluZy5zcGxpdCB%2Bc2VwOiJzdGFydCIgInN0YXJ0Lm9jYW1sLnJlYXNvbi5yZWFjdCIpOwpKcy5sb2coSnMuU3RyaW5nLnNwbGl0IH5zZXA6ImVuZCIgIm9jYW1sLnJlYXNvbi5yZWFjdC5lbmQiKTsKSnMubG9nKEpzLlN0cmluZy5zcGxpdCB%2Bc2VwOiJib3RoIiAiYm90aC5vY2FtbC5yZWFzb24ucmVhY3QuYm90aCIpOw%3D%3D&live=off *)
-      match (str_start_with_sep, str_end_with_sep, sep <> "") with
-      (* If the string starts and ends with the separator, we need to add an empty string at the beginning and the end *)
-      | true, true, true -> ("" :: Str.split regexp str) @ [ "" ]
-      (* If the string starts with the separator, we need to add an empty string at the beginning *)
-      | true, false, true -> "" :: Str.split regexp str
-      (* If the string ends with the separator, we need to add an empty string at the end *)
-      | false, true, true -> Str.split regexp str @ [ "" ]
-      (* If the string doesn't start or end with the separator, we just split it *)
-      | _ -> Str.split regexp str
-    in
-    let items = items |> Stdlib.Array.of_list in
+    (* On js split, it don't return an empty string on end when separator is an empty string *)
+    (* but "split_delim" does *)
+    (* https://melange.re/unstable/playground/?language=OCaml&code=SnMubG9nKEpzLlN0cmluZy5zcGxpdCB%2Bc2VwOiIiICJzdGFydCIpOw%3D%3D&live=off *)
+    let split = if sep <> "" then Str.split_delim else Str.split in
+    let items = split regexp str |> Stdlib.Array.of_list in
     let limit = Option.value limit ~default:(Stdlib.Array.length items) in
     match limit with
     | limit when limit >= 0 && limit < Stdlib.Array.length items ->

--- a/packages/melange.js/Js.mli
+++ b/packages/melange.js/Js.mli
@@ -380,11 +380,7 @@ module String : sig
     not_implemented "is not implemented in native under server-reason-react.js"]
 
   val slice : ?start:int -> ?end_:int -> t -> t
-
   val split : ?sep:t -> ?limit:int -> t -> t array
-  [@@alert
-    not_implemented "is not implemented in native under server-reason-react.js"]
-
   val splitByRe : regexp:Re.t -> ?limit:int -> t -> t nullable array
   val startsWith : prefix:t -> ?start:int -> t -> bool
   val substr : ?start:int -> ?len:int -> t -> t

--- a/packages/melange.js/dune
+++ b/packages/melange.js/dune
@@ -9,7 +9,7 @@
  (public_name server-reason-react.js)
  (libraries quickjs lwt str)
  (preprocess
-  (pps lwt_ppx browser_ppx)))
+  (pps lwt_ppx)))
 
 (test
  (name test)

--- a/packages/melange.js/dune
+++ b/packages/melange.js/dune
@@ -9,7 +9,7 @@
  (public_name server-reason-react.js)
  (libraries quickjs lwt str)
  (preprocess
-  (pps lwt_ppx)))
+  (pps lwt_ppx browser_ppx)))
 
 (test
  (name test)

--- a/packages/melange.js/test.ml
+++ b/packages/melange.js/test.ml
@@ -302,6 +302,7 @@ let string_tests =
         (* assert_string (Js.String.sliceToEnd ~from:(-2) "abcdefg") "fg"; *)
         assert_string (Js.String.slice ~start:7 "abcdefg") "");
     test "split" (fun () ->
+        assert_string_array (Js.String.split ~sep:"" "") [||];
         assert_string_array
           (Js.String.split ~sep:"-" "2018-01-02")
           [| "2018"; "01"; "02" |];

--- a/packages/melange.js/test.ml
+++ b/packages/melange.js/test.ml
@@ -302,15 +302,44 @@ let string_tests =
         (* assert_string (Js.String.sliceToEnd ~from:(-2) "abcdefg") "fg"; *)
         assert_string (Js.String.slice ~start:7 "abcdefg") "");
     test "split" (fun () ->
-        (* assert_string_array (split "-" "2018-01-02") [| "2018"; "01"; "02" |];
-           assert_string_array (split "," "a,b,,c") [| "a"; "b"; ""; "c" |];
-           assert_string_array
-             (split "::" "good::bad as great::awful")
-             [| "good"; "bad as great"; "awful" |];
-           assert_string_array
-             (split ";" "has-no-delimiter")
-             [| "has-no-delimiter" |] *)
-        ());
+        assert_string_array
+          (Js.String.split ~sep:"-" "2018-01-02")
+          [| "2018"; "01"; "02" |];
+        assert_string_array
+          (Js.String.split ~sep:"," "a,b,,c")
+          [| "a"; "b"; ""; "c" |];
+        assert_string_array
+          (Js.String.split ~sep:"::" "good::bad as great::awful")
+          [| "good"; "bad as great"; "awful" |];
+        assert_string_array
+          (Js.String.split ~sep:";" "has-no-delimiter")
+          [| "has-no-delimiter" |];
+        assert_string_array
+          (Js.String.split ~sep:"with" "with-sep-equals-to-beginning")
+          [| ""; "-sep-equals-to-beginning" |];
+        assert_string_array
+          (Js.String.split ~sep:"end" "with-sep-equals-to-end")
+          [| "with-sep-equals-to-"; "" |];
+        assert_string_array
+          (Js.String.split ~sep:"/" "/with-sep-on-beginning-and-end/")
+          [| ""; "with-sep-on-beginning-and-end"; "" |];
+        assert_string_array
+          (Js.String.split ~sep:"" "with-empty-sep")
+          [|
+            "w"; "i"; "t"; "h"; "-"; "e"; "m"; "p"; "t"; "y"; "-"; "s"; "e"; "p";
+          |];
+        assert_string_array
+          (Js.String.split ~sep:"-" "with-limit-equals-to-zero" ~limit:0)
+          [||];
+        assert_string_array
+          (Js.String.split ~sep:"-" "with-limit-equals-to-length" ~limit:5)
+          [| "with"; "limit"; "equals"; "to"; "length" |];
+        assert_string_array
+          (Js.String.split ~sep:"-" "with-limit-greater-than-length" ~limit:100)
+          [| "with"; "limit"; "greater"; "than"; "length" |];
+        assert_string_array
+          (Js.String.split ~sep:"-" "with-limit-less-than-zero" ~limit:(-2))
+          [| "with"; "limit"; "less"; "than"; "zero" |]);
     test "splitAtMost" (fun () ->
         (* assert_string_array
              (splitAtMost "/" ~limit:3 "ant/bee/cat/dog/elk")


### PR DESCRIPTION
## Description

This PR adds a native code to `Js.String.split`.
Before it was `notImplemented "Js.String" **"split"**`.

## How

`server-reason-react.js` has a melange behavior, so we need to keep it: 

#### API

Melange:
```ocaml
external split : ?sep:t -> ?limit:int -> t array = "split"
```

Native:
```ocaml
val split : ?sep:t -> ?limit:int -> t -> t array
```

### Interesting Cases 

I've separated some interesting cases regarding melange `String.split` behavior that was added to native code: 

- When `sep` matches some content at the beginning, it returns this match as an empty string  at the beginning of the list ([playground](https://melange.re/unstable/playground/?language=OCaml&code=SnMubG9nKEpzLlN0cmluZy5zcGxpdCB%2Bc2VwOiJvY2FtbCIgIm9jYW1sLnJlYXNvbi5yZWFjdCIp&live=off))
  <img width="652" alt="Captura de Tela 2024-08-23 às 09 25 07" src="https://github.com/user-attachments/assets/873c3116-7a9d-475d-bcda-d554fc565887">

- When sep matches some content at the end, it returns this match as an empty string at the end of the list ([playground](https://melange.re/unstable/playground/?language=OCaml&code=SnMubG9nKEpzLlN0cmluZy5zcGxpdCB%2Bc2VwOiJyZWFjdCIgIm9jYW1sLnJlYXNvbi5yZWFjdCIp&live=off))
  <img width="659" alt="Captura de Tela 2024-08-23 às 09 24 53" src="https://github.com/user-attachments/assets/34cf4806-e0e3-4c63-a400-1ec100d07c00">

- When sep matches some content at the end and the beginning, it returns this match as an empty string at the end and beginning of the list ([playground](https://melange.re/unstable/playground/?language=OCaml&code=SnMubG9nKEpzLlN0cmluZy5zcGxpdCB%2Bc2VwOiIvIiAiL29jYW1sLnJlYXNvbi5yZWFjdC8iKQ%3D%3D&live=off))
  <img width="735" alt="Captura de Tela 2024-08-23 às 09 31 23" src="https://github.com/user-attachments/assets/b7068ae1-57ba-4799-8a6e-7ef4a859f0b3">


- When sep is empty, it returns all the items ([playground](https://melange.re/unstable/playground/?language=OCaml&code=SnMubG9nKEpzLlN0cmluZy5zcGxpdCAib2NhbWwucmVhc29uLnJlYWN0Iik%3D&live=off))
  <img width="682" alt="Captura de Tela 2024-08-23 às 09 25 28" src="https://github.com/user-attachments/assets/53c5ccda-e908-4b8d-be11-ba5e4cec9544">

- When sep has no value, it returns all chars splitted ([playground](https://melange.re/unstable/playground/?language=OCaml&code=SnMubG9nKEpzLlN0cmluZy5zcGxpdCAib2NhbWwucmVhc29uLnJlYWN0Iik%3D&live=off))
  <img width="897" alt="Captura de Tela 2024-08-23 às 09 25 41" src="https://github.com/user-attachments/assets/d0b1d467-4e00-4311-b479-c48c9352ddcd">

- Limit greater than array length returns all the items ([playground](https://melange.re/unstable/playground/?language=OCaml&code=SnMubG9nKEpzLlN0cmluZy5zcGxpdCB%2Bc2VwOiIuIiB%2BbGltaXQ6KDEwMCkgIm9jYW1sLnJlYXNvbi5yZWFjdCIp&live=off))
  <img width="733" alt="Captura de Tela 2024-08-22 às 17 08 29" src="https://github.com/user-attachments/assets/d46622ec-c340-4244-a58f-3de4fbe8179d">

- Limit less than zero returns all the items ([playground](https://melange.re/unstable/playground/?language=OCaml&code=SnMubG9nKEpzLlN0cmluZy5zcGxpdCB%2Bc2VwOiIuIiB%2BbGltaXQ6KC0yKSAib2NhbWwucmVhc29uLnJlYWN0Iik%3D&live=off)) 
  <img width="769" alt="Captura de Tela 2024-08-22 às 17 08 38" src="https://github.com/user-attachments/assets/af33458a-6f83-4720-a911-74e6ac92b3a8">





