### PR TITLE
feat: add nested mel.obj support

### DIFF
--- a/packages/melange.ppx/ppx.ml
+++ b/packages/melange.ppx/ppx.ml
@@ -765,6 +765,7 @@ class raise_exception_mapper (module_path : string) =
     inherit Ast_traverse.map as super
 
     method! expression expr =
+      let expr = super#expression expr in
       match expr.pexp_desc with
       | Pexp_extension
           ( { txt = "mel.obj"; _ },
@@ -787,7 +788,7 @@ class raise_exception_mapper (module_path : string) =
                 record literal")
       | Pexp_constant (Pconst_string (s, loc, Some "j")) ->
           String_interpolation.transform ~loc expr s
-      | _ -> super#expression expr
+      | _ -> expr
 
     method! structure_item item =
       match item.pstr_desc with

--- a/packages/melange.ppx/tests/mel_obj.t
+++ b/packages/melange.ppx/tests/mel_obj.t
@@ -13,6 +13,26 @@ Transform mel.obj into OCaml object literals
 
   $ ocamlc -c output.ml
 
+Transform nested mel.obj into OCaml object literals
+
+  $ cat > input.ml << EOF
+  > let a = [%mel.obj { lola = 33; cositas = [%mel.obj { value = "hola" }]}]
+  > EOF
+
+  $ ./standalone.exe -impl input.ml | ocamlformat - --enable-outside-detected-project --impl | tee output.ml
+  let a =
+    object
+      method cositas =
+        object
+          method value = "hola"
+        end
+  
+      method lola = 33
+    end
+
+  $ ocamlc -c output.ml
+
+
 Fail if the object is not a record
 
   $ cat > input.ml << EOF


### PR DESCRIPTION
## Description

Melange support nested `mel.obj`.
Example:
<table>
<tr>
<td> OCaml </td> <td> Reasonml </td>
</tr>
<tr>
<td>

```ocaml
let person = [%mel.obj { data = ([%mel.obj { name = "Pedro" }]) }]
```

</td>
<td>

```reason
let person = {
  "data": {
    "name": "Pedro",
  },
};
```

</td>
</tr>
</table>

We can see it working in the [Playground](https://melange.re/unstable/playground/?language=Reason&code=bGV0IHBlcnNvbiA9IHsKICAiZGF0YSI6IHsKICAgICJuYW1lIjogIlBlZHJvIiwKICB9LAp9OwoKSnMubG9nKHBlcnNvbiMjZGF0YSMjbmFtZSkK&live=off)

So this PR adds the same support to native `mel.obj`, as if you try to use it, it breaks:

<img width="515" alt="Captura de Tela 2024-10-02 às 15 40 51" src="https://github.com/user-attachments/assets/5bd0742e-0401-4e12-a737-e2be50454f33">


## How to test

- Access any `reasonml/ocaml` file in the demo
- Add a nested Js.t object, like the example above
- See that no error is shown