### PR TITLE
Support non-ascii on JS.String.toLowerCase and toUpperCase

### DIFF
--- a/demo/universal/native/lib/HelloWorld.re
+++ b/demo/universal/native/lib/HelloWorld.re
@@ -1,9 +1,8 @@
 [@react.component]
-let make = () => {
+let make = () =>
   <html>
     <body>
-      <h1> {React.string("Hello World")} </h1>
+      <h1> {React.string(Js.String.toLowerCase("Hello World"))} </h1>
       <p> {React.string("This is an example")} </p>
     </body>
   </html>;
-};

--- a/dune-project
+++ b/dune-project
@@ -30,6 +30,7 @@
   (melange (>= 3.0.0))
 
   ; Library dependencies
+  (uucp (>= 16.0.0))
   (ppxlib (> 0.23.0))
   (quickjs (>= 0.1.2))
   (promise (>= 1.1.2))

--- a/packages/melange.js/dune
+++ b/packages/melange.js/dune
@@ -7,7 +7,7 @@
  (name js)
  (modules js)
  (public_name server-reason-react.js)
- (libraries quickjs lwt str)
+ (libraries quickjs lwt str uucp)
  (preprocess
   (pps lwt_ppx)))
 

--- a/packages/melange.js/test.ml
+++ b/packages/melange.js/test.ml
@@ -411,13 +411,31 @@ let string_tests =
           "playground";
         assert_string (Js.String.substring ~start:12 "playground") "");
     test "toLowerCase" (fun () ->
-        assert_string (Js.String.toLowerCase "ABC") "abc"
-        (* assert_string (Js.String.toLowerCase {js|ΣΠ|js}) {js|σπ|js}; *)
-        (* assert_string (Js.String.toLowerCase {js|ΠΣ|js}) {js|πς|js} *));
+        assert_string (Js.String.toLowerCase "") "";
+        assert_string (Js.String.toLowerCase "ASCII: ABC") "ascii: abc";
+        assert_string (Js.String.toLowerCase "Non ASCII: ΣΠ") "non ascii: σπ";
+        assert_string
+          (Js.String.toLowerCase "Unicode Σ: \u{03a3}")
+          "unicode σ: \u{03c3}";
+        assert_string
+          (Js.String.toLowerCase
+             "Unicode Mongolian separator + Σ + Mongolian separator: \u{180E} \
+              + \u{03a3} + \u{180E}")
+          "unicode mongolian separator + σ + mongolian separator: \u{180E} + \
+           \u{03c3} + \u{180E}");
     test "toUpperCase" (fun () ->
-        assert_string (Js.String.toUpperCase "abc") "ABC"
-        (* assert_string (Js.String.toUpperCase {js|Straße|js}) {js|STRASSE|js} *)
-        (* assert_string (Js.String.toLowerCase {js|πς|js}) {js|ΠΣ|js} *));
+        assert_string (Js.String.toUpperCase "") "";
+        assert_string (Js.String.toUpperCase "abc") "ABC";
+        assert_string (Js.String.toUpperCase "Non ASCII: σπ") "NON ASCII: ΣΠ";
+        assert_string
+          (Js.String.toUpperCase "Unicode: \u{03c3}")
+          "UNICODE: \u{03a3}";
+        assert_string
+          (Js.String.toUpperCase
+             "Unicode Mongolian separator + σ + Mongolian separator: \u{180E} \
+              + \u{03c3} + \u{180E}")
+          "UNICODE MONGOLIAN SEPARATOR + Σ + MONGOLIAN SEPARATOR: \u{180E} + \
+           \u{03a3} + \u{180E}");
     test "trim" (fun () ->
         assert_string (Js.String.trim "   abc def   ") "abc def";
         assert_string (Js.String.trim "\n\r\t abc def \n\n\t\r ") "abc def");

--- a/server-reason-react.opam
+++ b/server-reason-react.opam
@@ -11,6 +11,7 @@ depends: [
   "ocaml" {>= "5.0.0"}
   "reason" {>= "3.10.0"}
   "melange" {>= "3.0.0"}
+  "uucp" {>= "16.0.0"}
   "ppxlib" {> "0.23.0"}
   "quickjs" {>= "0.1.2"}
   "promise" {>= "1.1.2"}


### PR DESCRIPTION
## Issue: https://github.com/ml-in-barcelona/server-reason-react/issues/172

## Description

This PR adds the support of non-ascii on `JS.String.toLowerCase` and `toUpperCase`

## How

I am using the `uucp` library to support it: https://github.com/ocaml-community/Camomile/tree/main
And I don't know about performance with others way, but I ran the bench with this code:
```reason
[@react.component]
let make = () => {
  let _ = Js.String.toLowerCase("Hello World");
  <html>
    <body>
      <h1> {React.string("Hello World")} </h1>
      <p> {React.string("This is an example")} </p>
    </body>
  </html>;
};
```
This branch (uucp):
![Captura de Tela 2024-10-25 às 10 21 02](https://github.com/user-attachments/assets/ccdbd81d-1d6b-428e-911b-db826c8344a4)

Main branch (without uucp):
![image](https://github.com/user-attachments/assets/5975e0c2-8b97-4ce0-8642-f113baf52dc8)