### PR TITLE
Add useSyncExternalStore hooks

### DIFF
--- a/packages/react/src/React.ml
+++ b/packages/react/src/React.ml
@@ -570,6 +570,14 @@ let useState (make_initial_value : unit -> 'state) =
   in
   (initial_value, setState)
 
+type ('input, 'output) callback = 'input -> 'output
+
+let useSyncExternalStore ~subscribe:_ ~getSnapshot = getSnapshot ()
+
+let useSyncExternalStoreWithServer ~subscribe:_ ~getSnapshot:_
+    ~getServerSnapshot =
+  getServerSnapshot ()
+
 let internal_id = ref 0
 
 let useId () =

--- a/packages/react/src/React.mli
+++ b/packages/react/src/React.mli
@@ -632,6 +632,22 @@ val useCallback5 : 'a -> 'b -> 'a
 val useCallback6 : 'a -> 'b -> 'a
 val useId : unit -> string
 
+type ('input, 'output) callback = 'input -> 'output
+
+val useSyncExternalStore :
+  subscribe:((unit -> unit) -> (unit, unit) callback) ->
+  getSnapshot:(unit -> 'snapshot) ->
+  'snapshot
+[@@deprecated
+  "Use useSyncExternalStoreWithServer instead. More info at \
+   https://github.com/facebook/react/blob/603e6108f39c6663ec703eed34a89ff1bf0cb70c/packages/react-server/src/ReactFizzHooks.js#L561-L566"]
+
+val useSyncExternalStoreWithServer :
+  subscribe:((unit -> unit) -> (unit, unit) callback) ->
+  getSnapshot:(unit -> 'snapshot) ->
+  getServerSnapshot:(unit -> 'snapshot) ->
+  'snapshot
+
 val useReducer :
   ('state -> 'action -> 'state) -> 'state -> 'state * ('action -> unit)
 

--- a/packages/react/test/test_react.ml
+++ b/packages/react/test/test_react.ml
@@ -14,6 +14,20 @@ let use_state_doesnt_fire () =
   in
   assert_string (ReactDOM.renderToStaticMarkup app) "<div>foo</div>"
 
+let use_sync_external_store_with_server () =
+  let app =
+    React.Upper_case_component
+      (fun () ->
+        let value =
+          React.useSyncExternalStoreWithServer
+            ~getServerSnapshot:(fun () -> "foo")
+            ~subscribe:(fun _ () -> ())
+            ~getSnapshot:(fun _ -> "bar")
+        in
+        React.createElement "div" [] [ React.string value ])
+  in
+  assert_string (ReactDOM.renderToStaticMarkup app) "<div>foo</div>"
+
 let use_effect_doesnt_fire () =
   let app =
     React.Upper_case_component
@@ -73,6 +87,7 @@ let tests =
   ( "React",
     [
       test "useState" use_state_doesnt_fire;
+      test "useSyncExternalStoreWithServer" use_sync_external_store_with_server;
       test "useEffect" use_effect_doesnt_fire;
       test "Children.map" children_map_one_element;
       test "Children.map" children_map_list_element;


### PR DESCRIPTION
## Description 

The `useSyncExternalStore` and `useSyncExternalStoreWithServer` was missing on React hooks.

## How it works on server-reason-react 

For `useSyncExternalStore` it throws an error as react does not allowed to run it on a server without the `getServerSnapshot`. [Reference](https://github.com/facebook/react/blob/603e6108f39c6663ec703eed34a89ff1bf0cb70c/packages/react-server/src/ReactFizzHooks.js#L561-L566).

For `useSyncExternalStoreWithServer` we ignore all other params and call only the `getServerSnapshot` function.

Both follows the `react-reason` types: https://github.com/reasonml/reason-react/blob/c07e413750c5ca1632e6d3405a3cfbdf8d24c84e/src/React.rei#L192C1-L210C1