### PR TITLE
Create decodeURI and encodeURI

### DIFF
--- a/packages/melange.js/Js.ml
+++ b/packages/melange.js/Js.ml
@@ -1419,6 +1419,16 @@ end = struct
           Ok (Printf.sprintf "%%%c%c" first_digit second_digit)
       | _ -> Error (Printf.sprintf "Invalid hex encoding: %d" value)
 
+    let uri_char_escaped c =
+      match c with
+      | '\'' -> "'" (* treat single quote as a regular character *)
+      | c ->
+          (* use Char.escaped for other special characters that need escaping *)
+          let escaped = Char.escaped c in
+          if c = '\\' then
+            Stdlib.String.sub escaped 1 (String.length escaped - 1)
+          else escaped
+
     let encode_uri ~component s =
       let buf = Buffer.create (String.length s * 3) in
       let rec loop pos =
@@ -1429,7 +1439,7 @@ end = struct
             let new_pos = pos + 1 in
             if is_uri_unescaped c component then
               let encoded_char =
-                try Ok (Char.chr c |> Char.escaped)
+                try Ok (Char.chr c |> uri_char_escaped)
                 with _ -> raise (Invalid_argument "invalid character")
               in
               (new_pos, encoded_char)

--- a/packages/melange.js/Js.ml
+++ b/packages/melange.js/Js.ml
@@ -1328,14 +1328,137 @@ end = struct
   let setIntervalFloat ~f:_ _ = notImplemented "Js.Global" "setInterval"
   let setTimeout ~f:_ _ = notImplemented "Js.Global" "setTimeout"
   let setTimeoutFloat ~f:_ _ = notImplemented "Js.Global" "setTimeout"
-  let encodeURI _string = notImplemented "Js.Global" "encodeURI"
-  let decodeURI _string = notImplemented "Js.Global" "decodeURI"
 
-  let encodeURIComponent _string =
-    notImplemented "Js.Global" "encodeURIComponent"
+  module URI = struct
+    let int_of_hex_opt str =
+      try Some (Scanf.sscanf str "%x%!" (fun x -> x)) with _ -> None
 
-  let decodeURIComponent _string =
-    notImplemented "Js.Global" "decodeURIComponent"
+    let hex_decode str pos =
+      if pos + 2 >= String.length str then Error "Expecting Hex digit"
+      else
+        let first = int_of_hex_opt (Stdlib.String.sub str (pos + 1) 1) in
+        let second = int_of_hex_opt (Stdlib.String.sub str (pos + 2) 1) in
+        match (first, second) with
+        | Some first, Some second -> Ok ((first lsl 4) lor second)
+        | _ -> Error "Invalid hex digit"
+
+    let is_uri_reserved c = Stdlib.String.contains ";/?:@&=+$,#" c
+
+    let decode_uri ~component s =
+      let buf = Buffer.create (String.length s) in
+      let decode_utf8 pos char n c_min =
+        let rec loop pos char n =
+          if n <= 0 then Some (pos, char)
+          else
+            match hex_decode s pos with
+            | Ok c1 when c1 land 0xc0 = 0x80 ->
+                loop (pos + 3) ((char lsl 6) lor (c1 land 0x3f)) (n - 1)
+            | _ -> raise (Invalid_argument "Invalid hex encoding")
+        in
+        match loop pos char n with
+        | Some (new_pos, char)
+          when char >= c_min && char <= 0x10FFFF
+               && (char < 0xd800 || char >= 0xe000) ->
+            (new_pos, char)
+        | _ -> raise (Invalid_argument "Malformed UTF-8")
+      in
+      let rec loop pos =
+        if pos >= String.length s then Buffer.contents buf
+        else
+          match Stdlib.String.get s pos with
+          | '%' -> (
+              match hex_decode s pos with
+              | Ok hex when hex >= 0 ->
+                  if hex < 0x80 then
+                    let c = Char.chr hex in
+                    if (not component) && is_uri_reserved c then (
+                      Buffer.add_char buf '%';
+                      Buffer.add_string buf (Stdlib.String.sub s (pos + 1) 2);
+                      loop (pos + 3))
+                    else (
+                      Buffer.add_char buf c;
+                      loop (pos + 3))
+                  else
+                    let new_pos, decoded_char =
+                      if hex >= 0xc0 && hex <= 0xdf then
+                        decode_utf8 (pos + 3) (hex land 0x1f) 1 0x80
+                      else if hex >= 0xe0 && hex <= 0xef then
+                        decode_utf8 (pos + 3) (hex land 0x0f) 2 0x800
+                      else if hex >= 0xf0 && hex <= 0xf7 then
+                        decode_utf8 (pos + 3) (hex land 0x07) 3 0x10000
+                      else raise (Invalid_argument "Invalid UTF-8 start byte")
+                    in
+                    Buffer.add_utf_8_uchar buf (Uchar.of_int decoded_char);
+                    loop new_pos
+              | _ -> raise (Invalid_argument "Invalid hex encoding"))
+          | c ->
+              Buffer.add_char buf c;
+              loop (pos + 1)
+      in
+      try loop 0 with error -> raise error
+
+    let is_uri_unescaped c is_component =
+      c < 0x100
+      && ((c >= 0x61 && c <= 0x7a)
+         || (c >= 0x41 && c <= 0x5a)
+         || (c >= 0x30 && c <= 0x39)
+         || Stdlib.String.contains "-_.!~*'()" (Char.chr c)
+         || ((not is_component) && is_uri_reserved (Char.chr c)))
+
+    let hex_of_int_opt c =
+      let char_code =
+        if c < 10 then Char.code '0' + c else Char.code 'A' + (c - 10)
+      in
+      try Some (Char.chr char_code) with _ -> None
+
+    let encode_hex value =
+      let first_digit = hex_of_int_opt (value lsr 4) in
+      let second_digit = hex_of_int_opt (value land 0x0F) in
+      match (first_digit, second_digit) with
+      | Some first_digit, Some second_digit ->
+          Ok (Printf.sprintf "%%%c%c" first_digit second_digit)
+      | _ -> Error (Printf.sprintf "Invalid hex encoding: %d" value)
+
+    let encode_uri ~component s =
+      let buf = Buffer.create (String.length s * 3) in
+      let rec loop pos =
+        if pos >= String.length s then Buffer.contents buf
+        else
+          let new_pos, encoded_char =
+            let c = Char.code (Stdlib.String.get s pos) in
+            let new_pos = pos + 1 in
+            if is_uri_unescaped c component then
+              let encoded_char =
+                try Ok (Char.chr c |> Char.escaped)
+                with _ -> raise (Invalid_argument "invalid character")
+              in
+              (new_pos, encoded_char)
+            else if c >= 0xdc00 && c <= 0xdfff then
+              raise (Invalid_argument "invalid character")
+            else if c >= 0xd800 && c <= 0xdbff then (
+              if new_pos >= String.length s then
+                raise (Invalid_argument "expecting surrogate pair");
+              let c1 = Char.code (Stdlib.String.get s new_pos) in
+              if c1 < 0xdc00 || c1 > 0xdfff then
+                raise (Invalid_argument "expecting surrogate pair");
+              let c = (((c land 0x3ff) lsl 10) lor (c1 land 0x3ff)) + 0x10000 in
+              (new_pos + 1, encode_hex c))
+            else (new_pos, encode_hex c)
+          in
+
+          match encoded_char with
+          | Ok encoded_char ->
+              Buffer.add_string buf encoded_char;
+              loop new_pos
+          | Error msg -> raise (Invalid_argument msg)
+      in
+      loop 0
+  end
+
+  let encodeURI = URI.encode_uri ~component:false
+  let decodeURI = URI.decode_uri ~component:false
+  let encodeURIComponent = URI.encode_uri ~component:true
+  let decodeURIComponent = URI.decode_uri ~component:true
 end
 
 module Types = struct

--- a/packages/melange.js/Js.mli
+++ b/packages/melange.js/Js.mli
@@ -862,20 +862,9 @@ module Global : sig
     not_implemented "is not implemented in native under server-reason-react.js"]
 
   val encodeURI : string -> string
-  [@@alert
-    not_implemented "is not implemented in native under server-reason-react.js"]
-
   val decodeURI : string -> string
-  [@@alert
-    not_implemented "is not implemented in native under server-reason-react.js"]
-
   val encodeURIComponent : string -> string
-  [@@alert
-    not_implemented "is not implemented in native under server-reason-react.js"]
-
   val decodeURIComponent : string -> string
-  [@@alert
-    not_implemented "is not implemented in native under server-reason-react.js"]
 end
 
 module Types : sig

--- a/packages/melange.js/test.ml
+++ b/packages/melange.js/test.ml
@@ -480,6 +480,13 @@ let global_tests =
         assert_string (Js.Global.decodeURI "%5B%5D") "[]";
         assert_string (Js.Global.decodeURI "%7B%7D") "{}";
         assert_string (Js.Global.decodeURI "%7C") "|");
+    test "decodeURI - mixed percent encodings and Unicode" (fun () ->
+        assert_string
+          (Js.Global.decodeURI "Hello%20%E4%BD%A0%E5%A5%BD%20World")
+          "Hello 你好 World";
+        assert_string
+          (Js.Global.decodeURI "%E2%82%AC%20%24%20%C2%A3%20%C2%A5")
+          "€ %24 £ ¥");
     test "decodeURI - complete URLs" (fun () ->
         assert_string
           (Js.Global.decodeURI
@@ -492,6 +499,9 @@ let global_tests =
         assert_string
           (Js.Global.decodeURI "https://example.com/path%20name/file.txt")
           "https://example.com/path name/file.txt");
+    test "decodeURI - overencoded sequences" (fun () ->
+        assert_string (Js.Global.decodeURI "Hello%2520World") "Hello%20World";
+        assert_string (Js.Global.decodeURI "%25252525") "%252525");
     test "decodeURI - special characters" (fun () ->
         assert_string (Js.Global.decodeURI "%0A") "\n";
         assert_string (Js.Global.decodeURI "%0D") "\r";
@@ -503,8 +513,8 @@ let global_tests =
           "Hello%20%20%20World";
         assert_string (Js.Global.encodeURI "Hello-World") "Hello-World");
     test "encodeURI - reserved characters" (fun () ->
-        assert_string (Js.Global.encodeURI ";,/?:@&=+$#") ";,/?:@&=+$#"
-        (* assert_string (Js.Global.encodeURI "-_.!~*'()") "-_.!~*'()" *));
+        assert_string (Js.Global.encodeURI ";,/?:@&=+$#") ";,/?:@&=+$#";
+        assert_string (Js.Global.encodeURI "-_.!~*'()") "-_.!~*'()");
     test "encodeURI - alphabets" (fun () ->
         assert_string
           (Js.Global.encodeURI "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -523,7 +533,6 @@ let global_tests =
         assert_string
           (Js.Global.encodeURI "http://unipro.ru/0123456789")
           "http://unipro.ru/0123456789";
-
         assert_string
           (Js.Global.encodeURI
              "http://www.google.ru/support/jobs/bin/static.py?page=why-ru.html&sid=liveandwork")
@@ -554,6 +563,26 @@ let global_tests =
         assert_string
           (Js.Global.encodeURI "http://unipro.ru/\rabout")
           "http://unipro.ru/%0Dabout");
+    test "encodeURI - combining characters" (fun () ->
+        (* Characters with combining diacritical marks *)
+        assert_string
+          (Js.Global.encodeURI "é") (* e + acute accent as single char *)
+          "%C3%A9";
+        assert_string
+          (Js.Global.encodeURI "e\u{0301}") (* e + combining acute accent *)
+          "e%CC%81";
+        assert_string
+          (Js.Global.encodeURI "ế") (* e + circumflex + acute *)
+          "%E1%BA%BF");
+    test "encodeURI - Surrogate pairs" (fun () ->
+        (* Surrogate pairs for emoji and complex Unicode *)
+        assert_string
+          (Js.Global.encodeURI "𝌆") (* Musical symbol *)
+          "%F0%9D%8C%86";
+        assert_string (Js.Global.encodeURI "🌍") (* Earth globe *) "%F0%9F%8C%8D";
+        assert_string
+          (Js.Global.encodeURI "👨‍👩‍👧‍👦") (* Family emoji with ZWJ sequences *)
+          "%F0%9F%91%A8%E2%80%8D%F0%9F%91%A9%E2%80%8D%F0%9F%91%A7%E2%80%8D%F0%9F%91%A6");
     (* \v and \f are not supported in ocaml *)
     (*
        assert_string

--- a/packages/melange.js/test.ml
+++ b/packages/melange.js/test.ml
@@ -453,7 +453,54 @@ let string_tests =
 
 let global_tests =
   [
-    test "decodeURI" (fun () ->
+    test "decodeURI - basic ascii characters" (fun () ->
+        assert_string (Js.Global.decodeURI "Hello%20World") "Hello World");
+    test "decodeURI - basic decoded characters" (fun () ->
+        assert_string (Js.Global.decodeURI "%20") " ";
+        assert_string (Js.Global.decodeURI "%25") "%";
+        assert_string (Js.Global.decodeURI "%3C%3E") "<>";
+        assert_string (Js.Global.decodeURI "%22") "\"";
+        assert_string (Js.Global.decodeURI "%5C") "\\";
+        assert_string (Js.Global.decodeURI "%E2%82%AC") "€";
+        assert_string (Js.Global.decodeURI "%E2%98%85") "★";
+        assert_string (Js.Global.decodeURI "%E2%99%A0") "♠";
+        assert_string (Js.Global.decodeURI "%E4%BD%A0%E5%A5%BD") "你好");
+    test "decodeURI - characters that should not be decoded" (fun () ->
+        (* Reserved characters that should not be decoded *)
+        assert_string (Js.Global.decodeURI ";,/?:@&=+$#") ";,/?:@&=+$#";
+
+        (* Unreserved characters that should not be encoded *)
+        assert_string
+          (Js.Global.decodeURI "abcdefghijklmnopqrstuvwxyz")
+          "abcdefghijklmnopqrstuvwxyz";
+        assert_string
+          (Js.Global.decodeURI "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        assert_string
+          (Js.Global.decodeURI "0123456789-_.!~*'()")
+          "0123456789-_.!~*'()");
+    test "decodeURI - multiple encoded sequences" (fun () ->
+        assert_string
+          (Js.Global.decodeURI "Hello%20World!%20%E2%98%85")
+          "Hello World! ★";
+        assert_string
+          (Js.Global.decodeURI "Path/To/File%20Name")
+          "Path/To/File Name";
+        assert_string (Js.Global.decodeURI "") "";
+        assert_string (Js.Global.decodeURI "%20") " ";
+        assert_string (Js.Global.decodeURI "%20%20%20") "   ";
+        assert_string (Js.Global.decodeURI "%2520") "%20");
+    test "shit" (fun () ->
+        assert_string
+          (Js.Global.decodeURI "https://example.com/path%20name/file.txt")
+          "https://example.com/path name/file.txt";
+
+        assert_string (Js.Global.decodeURI "%5B%5D") "[]";
+
+        assert_string (Js.Global.decodeURI "%7B%7D") "{}";
+
+        assert_string (Js.Global.decodeURI "%7C") "|");
+    test "decodeURI - url" (fun () ->
         assert_string
           (Js.Global.decodeURI "http:%2f%2Funipro.ru")
           "http:%2f%2Funipro.ru";

--- a/packages/melange.js/test.ml
+++ b/packages/melange.js/test.ml
@@ -453,157 +453,115 @@ let string_tests =
 
 let global_tests =
   [
-    test "decodeURI - basic ascii characters" (fun () ->
-        assert_string (Js.Global.decodeURI "Hello%20World") "Hello World");
-    test "decodeURI - basic decoded characters" (fun () ->
-        assert_string (Js.Global.decodeURI "%20") " ";
-        assert_string (Js.Global.decodeURI "%25") "%";
-        assert_string (Js.Global.decodeURI "%3C%3E") "<>";
-        assert_string (Js.Global.decodeURI "%22") "\"";
-        assert_string (Js.Global.decodeURI "%5C") "\\";
-        assert_string (Js.Global.decodeURI "%E2%82%AC") "€";
-        assert_string (Js.Global.decodeURI "%E2%98%85") "★";
-        assert_string (Js.Global.decodeURI "%E2%99%A0") "♠";
-        assert_string (Js.Global.decodeURI "%E4%BD%A0%E5%A5%BD") "你好");
-    test "decodeURI - characters that should not be decoded" (fun () ->
-        (* Reserved characters that should not be decoded *)
-        assert_string (Js.Global.decodeURI ";,/?:@&=+$#") ";,/?:@&=+$#";
-
-        (* Unreserved characters that should not be encoded *)
+    test "decodeURI - ascii and spaces" (fun () ->
+        assert_string (Js.Global.decodeURI "Hello%20World") "Hello World";
         assert_string
-          (Js.Global.decodeURI "abcdefghijklmnopqrstuvwxyz")
-          "abcdefghijklmnopqrstuvwxyz";
+          (Js.Global.decodeURI "Hello%20%20%20World")
+          "Hello   World";
+        assert_string (Js.Global.decodeURI "Hello%2DWorld") "Hello-World");
+    test "decodeURI - reserved characters" (fun () ->
+        assert_string (Js.Global.decodeURI ";,/?:@&=+$#") ";,/?:@&=+$#";
+        assert_string (Js.Global.decodeURI "-_.!~*'()") "-_.!~*'()");
+    test "decodeURI - alphabets" (fun () ->
         assert_string
           (Js.Global.decodeURI "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
           "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         assert_string
-          (Js.Global.decodeURI "0123456789-_.!~*'()")
-          "0123456789-_.!~*'()");
-    test "decodeURI - multiple encoded sequences" (fun () ->
+          (Js.Global.decodeURI "abcdefghijklmnopqrstuvwxyz")
+          "abcdefghijklmnopqrstuvwxyz";
+        assert_string (Js.Global.decodeURI "0123456789") "0123456789");
+    test "decodeURI - unicode characters" (fun () ->
         assert_string
-          (Js.Global.decodeURI "Hello%20World!%20%E2%98%85")
-          "Hello World! ★";
-        assert_string
-          (Js.Global.decodeURI "Path/To/File%20Name")
-          "Path/To/File Name";
-        assert_string (Js.Global.decodeURI "") "";
-        assert_string (Js.Global.decodeURI "%20") " ";
-        assert_string (Js.Global.decodeURI "%20%20%20") "   ";
-        assert_string (Js.Global.decodeURI "%2520") "%20");
-    test "shit" (fun () ->
-        assert_string
-          (Js.Global.decodeURI "https://example.com/path%20name/file.txt")
-          "https://example.com/path name/file.txt";
-
+          (Js.Global.decodeURI "%D0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4")
+          "Юникод";
+        assert_string (Js.Global.decodeURI "%E2%82%AC%E2%98%85%E2%99%A0") "€★♠";
+        assert_string (Js.Global.decodeURI "%E4%BD%A0%E5%A5%BD") "你好");
+    test "" (fun () ->
         assert_string (Js.Global.decodeURI "%5B%5D") "[]";
-
         assert_string (Js.Global.decodeURI "%7B%7D") "{}";
-
         assert_string (Js.Global.decodeURI "%7C") "|");
-    test "decodeURI - url" (fun () ->
-        assert_string
-          (Js.Global.decodeURI "http:%2f%2Funipro.ru")
-          "http:%2f%2Funipro.ru";
+    test "decodeURI - complete URLs" (fun () ->
         assert_string
           (Js.Global.decodeURI
-             "http://www.google.ru/support/jobs/bin/static.py%3Fpage%3dwhy-ru.html%26sid%3Dliveandwork")
-          "http://www.google.ru/support/jobs/bin/static.py%3Fpage%3dwhy-ru.html%26sid%3Dliveandwork";
-        assert_string
-          (Js.Global.decodeURI
-             "http://ru.wikipedia.org/wiki/%d0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4")
+             "http://ru.wikipedia.org/wiki/%D0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4")
           "http://ru.wikipedia.org/wiki/Юникод";
         assert_string
           (Js.Global.decodeURI
-             "http://ru.wikipedia.org/wiki/%D0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4%23%D0%92%D0%B5%D1%80%D1%81%D0%B8%D0%B8%20%D0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4%D0%B0")
-          "http://ru.wikipedia.org/wiki/Юникод%23Версии Юникода";
-        assert_string
-          (Js.Global.decodeURI "http://unipro.ru/0123456789")
-          "http://unipro.ru/0123456789";
-        assert_string
-          (Js.Global.decodeURI
-             "%41%42%43%44%45%46%47%48%49%4A%4B%4C%4D%4E%4F%50%51%52%53%54%55%56%57%58%59%5A")
-          "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        assert_string
-          (Js.Global.decodeURI
-             "%61%62%63%64%65%66%67%68%69%6A%6B%6C%6D%6E%6F%70%71%72%73%74%75%76%77%78%79%7A")
-          "abcdefghijklmnopqrstuvwxyz";
-        assert_string
-          (Js.Global.decodeURI "http://unipro.ru/%0Aabout")
-          "http://unipro.ru/\nabout";
-        (* assert_string
-             (Js.Global.decodeURI "http://unipro.ru/%0Babout")
-             "http://unipro.ru/\vabout";
-           assert_string
-             (Js.Global.decodeURI "http://unipro.ru/%0Cabout")
-             "http://unipro.ru/\fabout"; *)
-        assert_string
-          (Js.Global.decodeURI "http://unipro.ru/%0Dabout")
-          "http://unipro.ru/\rabout");
-    test "decodeURIComponent" (fun () ->
-        assert_string
-          (Js.Global.decodeURIComponent "http%3A%2F%2Funipro.ru")
-          "http://unipro.ru";
-        assert_string
-          (Js.Global.decodeURIComponent
-             "http%3A%2F%2Fwww.google.ru%2Fsupport%2Fjobs%2Fbin%2Fstatic.py%3Fpage%3Dwhy-ru.html%26sid%3Dliveandwork")
+             "http://www.google.ru/support/jobs/bin/static.py?page=why-ru.html&sid=liveandwork")
           "http://www.google.ru/support/jobs/bin/static.py?page=why-ru.html&sid=liveandwork";
         assert_string
-          (Js.Global.decodeURIComponent
-             "%41%42%43%44%45%46%47%48%49%4A%4B%4C%4D%4E%4F%50%51%52%53%54%55%56%57%58%59%5A")
-          "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+          (Js.Global.decodeURI "https://example.com/path%20name/file.txt")
+          "https://example.com/path name/file.txt");
+    test "decodeURI - special characters" (fun () ->
+        assert_string (Js.Global.decodeURI "%0A") "\n";
+        assert_string (Js.Global.decodeURI "%0D") "\r";
+        assert_string (Js.Global.decodeURI "%3C%3E%22%5C") "<>\"\\");
+    test "encodeURI - ascii and spaces" (fun () ->
+        assert_string (Js.Global.encodeURI "Hello World") "Hello%20World";
         assert_string
-          (Js.Global.decodeURIComponent
-             "%61%62%63%64%65%66%67%68%69%6A%6B%6C%6D%6E%6F%70%71%72%73%74%75%76%77%78%79%7A")
-          "abcdefghijklmnopqrstuvwxyz";
-        assert_string
-          (Js.Global.decodeURIComponent "http%3A%2F%2Funipro.ru%2F%0Aabout")
-          "http://unipro.ru/\nabout";
-        assert_string
-          (Js.Global.decodeURIComponent "http://unipro.ru/%0Dabout")
-          "http://unipro.ru/\rabout");
-    (* \v and \f are not supported in ocaml
-       assert_string
-         (Js.Global.decodeURIComponent "http://unipro.ru/%0Babout")
-          "http://unipro.ru/\vabout";
-        assert_string
-          (Js.Global.decodeURIComponent "http://unipro.ru/%0Cabout")
-          "http://unipro.ru/\fabout"; *)
-    test "encodeURI" (fun () ->
-        assert_string
-          (Js.Global.encodeURI "http://ru.wikipedia.org/wiki/Юникод")
-          "http://ru.wikipedia.org/wiki/%D0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4";
-        assert_string
-          (Js.Global.encodeURI "http://unipro.ru/0123456789")
-          "http://unipro.ru/0123456789";
+          (Js.Global.encodeURI "Hello   World")
+          "Hello%20%20%20World";
+        assert_string (Js.Global.encodeURI "Hello-World") "Hello-World");
+    test "encodeURI - reserved characters" (fun () ->
+        assert_string (Js.Global.encodeURI ";,/?:@&=+$#") ";,/?:@&=+$#"
+        (* assert_string (Js.Global.encodeURI "-_.!~*'()") "-_.!~*'()" *));
+    test "encodeURI - alphabets" (fun () ->
         assert_string
           (Js.Global.encodeURI "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
           "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
         assert_string
           (Js.Global.encodeURI "abcdefghijklmnopqrstuvwxyz")
           "abcdefghijklmnopqrstuvwxyz";
+        assert_string (Js.Global.encodeURI "0123456789") "0123456789");
+    test "encodeURI - unicode characters" (fun () ->
+        assert_string
+          (Js.Global.encodeURI "Юникод")
+          "%D0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4";
+        assert_string (Js.Global.encodeURI "€★♠") "%E2%82%AC%E2%98%85%E2%99%A0";
+        assert_string (Js.Global.encodeURI "你好") "%E4%BD%A0%E5%A5%BD");
+    test "encodeURI - complete URLs" (fun () ->
+        assert_string
+          (Js.Global.encodeURI "http://unipro.ru/0123456789")
+          "http://unipro.ru/0123456789";
+
         assert_string
           (Js.Global.encodeURI
              "http://www.google.ru/support/jobs/bin/static.py?page=why-ru.html&sid=liveandwork")
           "http://www.google.ru/support/jobs/bin/static.py?page=why-ru.html&sid=liveandwork";
         assert_string
-          (Js.Global.encodeURI "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-          "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+          (Js.Global.encodeURI "http://unipro.ru/\nabout")
+          "http://unipro.ru/%0Aabout";
         assert_string
-          (Js.Global.encodeURI "abcdefghijklmnopqrstuvwxyz")
-          "abcdefghijklmnopqrstuvwxyz";
+          (Js.Global.encodeURI "http://unipro.ru/\rabout")
+          "http://unipro.ru/%0Dabout";
+        assert_string
+          (Js.Global.encodeURI "http://ru.wikipedia.org/wiki/Юникод")
+          "http://ru.wikipedia.org/wiki/%D0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4";
+        assert_string
+          (Js.Global.encodeURI
+             "http://www.google.ru/support/jobs/bin/static.py?page=why-ru.html&sid=liveandwork")
+          "http://www.google.ru/support/jobs/bin/static.py?page=why-ru.html&sid=liveandwork";
+        assert_string
+          (Js.Global.encodeURI "https://example.com/path name/file.txt")
+          "https://example.com/path%20name/file.txt");
+    test "encodeURI - special characters" (fun () ->
+        assert_string (Js.Global.encodeURI "\n") "%0A";
+        assert_string (Js.Global.encodeURI "\r") "%0D";
+        assert_string (Js.Global.encodeURI "<>\"\\") "%3C%3E%22%5C";
         assert_string
           (Js.Global.encodeURI "http://unipro.ru/\nabout")
           "http://unipro.ru/%0Aabout";
         assert_string
           (Js.Global.encodeURI "http://unipro.ru/\rabout")
           "http://unipro.ru/%0Dabout");
-    (* \v and \f are not supported in ocaml
+    (* \v and \f are not supported in ocaml *)
+    (*
+       assert_string
+         (Js.Global.decodeURIComponent "http://unipro.ru/%0Babout")
+          "http://unipro.ru/\vabout";
         assert_string
-          (Js.Global.encodeURI "http://unipro.ru/\vabout")
-          "http://unipro.ru/%0Babout";
-        assert_string
-          (Js.Global.encodeURI "http://unipro.ru/\fabout")
-          "http://unipro.ru/%0Cabout"; *)
+          (Js.Global.decodeURIComponent "http://unipro.ru/%0Cabout")
+          "http://unipro.ru/\fabout"; *)
     test "encodeURIComponent" (fun () ->
         assert_string
           (Js.Global.encodeURIComponent "http://unipro.ru")

--- a/packages/melange.js/test.ml
+++ b/packages/melange.js/test.ml
@@ -451,6 +451,141 @@ let string_tests =
         ());
   ]
 
+let global_tests =
+  [
+    test "decodeURI" (fun () ->
+        assert_string
+          (Js.Global.decodeURI "http:%2f%2Funipro.ru")
+          "http:%2f%2Funipro.ru";
+        assert_string
+          (Js.Global.decodeURI
+             "http://www.google.ru/support/jobs/bin/static.py%3Fpage%3dwhy-ru.html%26sid%3Dliveandwork")
+          "http://www.google.ru/support/jobs/bin/static.py%3Fpage%3dwhy-ru.html%26sid%3Dliveandwork";
+        assert_string
+          (Js.Global.decodeURI
+             "http://ru.wikipedia.org/wiki/%d0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4")
+          "http://ru.wikipedia.org/wiki/Юникод";
+        assert_string
+          (Js.Global.decodeURI
+             "http://ru.wikipedia.org/wiki/%D0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4%23%D0%92%D0%B5%D1%80%D1%81%D0%B8%D0%B8%20%D0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4%D0%B0")
+          "http://ru.wikipedia.org/wiki/Юникод%23Версии Юникода";
+        assert_string
+          (Js.Global.decodeURI "http://unipro.ru/0123456789")
+          "http://unipro.ru/0123456789";
+        assert_string
+          (Js.Global.decodeURI
+             "%41%42%43%44%45%46%47%48%49%4A%4B%4C%4D%4E%4F%50%51%52%53%54%55%56%57%58%59%5A")
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        assert_string
+          (Js.Global.decodeURI
+             "%61%62%63%64%65%66%67%68%69%6A%6B%6C%6D%6E%6F%70%71%72%73%74%75%76%77%78%79%7A")
+          "abcdefghijklmnopqrstuvwxyz";
+        assert_string
+          (Js.Global.decodeURI "http://unipro.ru/%0Aabout")
+          "http://unipro.ru/\nabout";
+        (* assert_string
+             (Js.Global.decodeURI "http://unipro.ru/%0Babout")
+             "http://unipro.ru/\vabout";
+           assert_string
+             (Js.Global.decodeURI "http://unipro.ru/%0Cabout")
+             "http://unipro.ru/\fabout"; *)
+        assert_string
+          (Js.Global.decodeURI "http://unipro.ru/%0Dabout")
+          "http://unipro.ru/\rabout");
+    test "decodeURIComponent" (fun () ->
+        assert_string
+          (Js.Global.decodeURIComponent "http%3A%2F%2Funipro.ru")
+          "http://unipro.ru";
+        assert_string
+          (Js.Global.decodeURIComponent
+             "http%3A%2F%2Fwww.google.ru%2Fsupport%2Fjobs%2Fbin%2Fstatic.py%3Fpage%3Dwhy-ru.html%26sid%3Dliveandwork")
+          "http://www.google.ru/support/jobs/bin/static.py?page=why-ru.html&sid=liveandwork";
+        assert_string
+          (Js.Global.decodeURIComponent
+             "%41%42%43%44%45%46%47%48%49%4A%4B%4C%4D%4E%4F%50%51%52%53%54%55%56%57%58%59%5A")
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        assert_string
+          (Js.Global.decodeURIComponent
+             "%61%62%63%64%65%66%67%68%69%6A%6B%6C%6D%6E%6F%70%71%72%73%74%75%76%77%78%79%7A")
+          "abcdefghijklmnopqrstuvwxyz";
+        assert_string
+          (Js.Global.decodeURIComponent "http%3A%2F%2Funipro.ru%2F%0Aabout")
+          "http://unipro.ru/\nabout";
+        assert_string
+          (Js.Global.decodeURIComponent "http://unipro.ru/%0Dabout")
+          "http://unipro.ru/\rabout");
+    (* \v and \f are not supported in ocaml
+       assert_string
+         (Js.Global.decodeURIComponent "http://unipro.ru/%0Babout")
+          "http://unipro.ru/\vabout";
+        assert_string
+          (Js.Global.decodeURIComponent "http://unipro.ru/%0Cabout")
+          "http://unipro.ru/\fabout"; *)
+    test "encodeURI" (fun () ->
+        assert_string
+          (Js.Global.encodeURI "http://ru.wikipedia.org/wiki/Юникод")
+          "http://ru.wikipedia.org/wiki/%D0%AE%D0%BD%D0%B8%D0%BA%D0%BE%D0%B4";
+        assert_string
+          (Js.Global.encodeURI "http://unipro.ru/0123456789")
+          "http://unipro.ru/0123456789";
+        assert_string
+          (Js.Global.encodeURI "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        assert_string
+          (Js.Global.encodeURI "abcdefghijklmnopqrstuvwxyz")
+          "abcdefghijklmnopqrstuvwxyz";
+        assert_string
+          (Js.Global.encodeURI
+             "http://www.google.ru/support/jobs/bin/static.py?page=why-ru.html&sid=liveandwork")
+          "http://www.google.ru/support/jobs/bin/static.py?page=why-ru.html&sid=liveandwork";
+        assert_string
+          (Js.Global.encodeURI "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        assert_string
+          (Js.Global.encodeURI "abcdefghijklmnopqrstuvwxyz")
+          "abcdefghijklmnopqrstuvwxyz";
+        assert_string
+          (Js.Global.encodeURI "http://unipro.ru/\nabout")
+          "http://unipro.ru/%0Aabout";
+        assert_string
+          (Js.Global.encodeURI "http://unipro.ru/\rabout")
+          "http://unipro.ru/%0Dabout");
+    (* \v and \f are not supported in ocaml
+        assert_string
+          (Js.Global.encodeURI "http://unipro.ru/\vabout")
+          "http://unipro.ru/%0Babout";
+        assert_string
+          (Js.Global.encodeURI "http://unipro.ru/\fabout")
+          "http://unipro.ru/%0Cabout"; *)
+    test "encodeURIComponent" (fun () ->
+        assert_string
+          (Js.Global.encodeURIComponent "http://unipro.ru")
+          "http%3A%2F%2Funipro.ru";
+        assert_string
+          (Js.Global.encodeURIComponent
+             "http://www.google.ru/support/jobs/bin/static.py?page=why-ru.html&sid=liveandwork")
+          "http%3A%2F%2Fwww.google.ru%2Fsupport%2Fjobs%2Fbin%2Fstatic.py%3Fpage%3Dwhy-ru.html%26sid%3Dliveandwork";
+        assert_string
+          (Js.Global.encodeURIComponent "ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        assert_string
+          (Js.Global.encodeURIComponent "abcdefghijklmnopqrstuvwxyz")
+          "abcdefghijklmnopqrstuvwxyz";
+        assert_string
+          (Js.Global.encodeURIComponent "http://unipro.ru/\nabout")
+          "http%3A%2F%2Funipro.ru%2F%0Aabout";
+        assert_string
+          (Js.Global.encodeURIComponent "http://unipro.ru/\rabout")
+          "http%3A%2F%2Funipro.ru%2F%0Dabout");
+    (* \v and \f are not supported in ocaml
+       assert_string
+         (Js.Global.encodeURIComponent "http://unipro.ru/\vabout")
+         "http%3A%2F%2Funipro.ru%2F%0Babout";
+       assert_string
+         (Js.Global.encodeURIComponent "http://unipro.ru/\fabout")
+         "http%3A%2F%2Funipro.ru%2F%0Cabout"; *)
+  ]
+
 let obj () = Js.Dict.fromList [ ("foo", 43); ("bar", 86) ]
 let long_obj () = Js.Dict.fromList [ ("david", 99); ("foo", 43); ("bar", 86) ]
 
@@ -576,6 +711,7 @@ let () =
   Lwt_main.run
   @@ Alcotest_lwt.run "Js"
        [
+         ("Js.Global", global_tests);
          ("Js.Promise", promise_tests);
          ("Js.Float", float_tests);
          ("Js.String", string_tests);

--- a/packages/server-reason-react-ppx/cram/external.t/run.t
+++ b/packages/server-reason-react-ppx/cram/external.t/run.t
@@ -1,6 +1,5 @@
   $ ../ppx.sh --output re input.re
   module MyPropIsOptionOptionBoolWithSig = {
-    [%%ocaml.error
-      "externals aren't supported on server-reason-react. externals are used to bind to React components defined in JavaScript, in the server, that doesn't make sense. If you need to render this on the server, implement a placeholder or an empty element"
-    ];
+      [%ocaml.error
+       "externals aren't supported on server-reason-react. externals are used to bind to React components defined in JavaScript, in the server, that doesn't make sense. If you need to render this on the server, implement a placeholder or an empty element"];
   };

--- a/packages/server-reason-react-ppx/cram/external.t/run.t
+++ b/packages/server-reason-react-ppx/cram/external.t/run.t
@@ -1,5 +1,6 @@
   $ ../ppx.sh --output re input.re
   module MyPropIsOptionOptionBoolWithSig = {
-      [%ocaml.error
-       "externals aren't supported on server-reason-react. externals are used to bind to React components defined in JavaScript, in the server, that doesn't make sense. If you need to render this on the server, implement a placeholder or an empty element"];
+    [%%ocaml.error
+      "externals aren't supported on server-reason-react. externals are used to bind to React components defined in JavaScript, in the server, that doesn't make sense. If you need to render this on the server, implement a placeholder or an empty element"
+    ];
   };


### PR DESCRIPTION
# Issue #174

## Description

This PR attempts to add decodeURI, decodeURIComponent, encodeURI, and encodeURIComponent. It was strongly inspired by quick and aligning with JS tests: https://github.com/ml-in-barcelona/server-reason-react/issues/174#issuecomment-2427803044

## Process

The first attempt was basic copying the C code of quickjs as ocaml, but there were some issues that I wasn't able to identify what was wrong. That's why, besides its strong inspiration from Quickjs, the code differs from it in some approaches.

My eyes are also used to this code, so you may find some improvements that I don't, and please comment here about them.

