### PR TITLE
Update reason dependency

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,2 @@
+version = 0.26.2
 profile = default

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,1 @@
-version = 0.26.2
-profile = default
+profile=default

--- a/demo/universal/native/lib/Align.re
+++ b/demo/universal/native/lib/Align.re
@@ -1,5 +1,13 @@
-type verticalAlign = [ | `top | `center | `bottom];
-type horizontalAlign = [ | `left | `center | `right];
+type verticalAlign = [
+  | `top
+  | `center
+  | `bottom
+];
+type horizontalAlign = [
+  | `left
+  | `center
+  | `right
+];
 
 [@react.component]
 let make = (~h: horizontalAlign=`center, ~v: verticalAlign=`center, ~children) => {

--- a/demo/universal/native/lib/App.re
+++ b/demo/universal/native/lib/App.re
@@ -30,7 +30,10 @@ module Title = {
           label: "Issues",
           link: "https://github.com/ml-in-barcelona/server-reason-react/issues",
         },
-        {label: "About", link: "https://twitter.com/davesnx"},
+        {
+          label: "About",
+          link: "https://twitter.com/davesnx",
+        },
       |];
 
       <div

--- a/demo/universal/native/lib/MelRaw.re
+++ b/demo/universal/native/lib/MelRaw.re
@@ -1,13 +1,12 @@
-let%browser_only mockInitWebsocket = () => [%mel.raw
-  {|
+let%browser_only mockInitWebsocket = () =>
+  {%mel.raw |
   function mockInitWebsocket() {
     console.log("Load JS");
   }
-|}
-];
+|};
 
-let%browser_only initWebsocket = () => [%mel.raw
-  {|
+let%browser_only initWebsocket = () =>
+  {%mel.raw |
        function initWebsocket() {
          var socketUrl = "ws://" + location.host + "/_livereload";
          var s = new WebSocket(socketUrl);
@@ -40,7 +39,6 @@ let%browser_only initWebsocket = () => [%mel.raw
            console.debug("Live reload: WebSocket error:", event);
          };
        }
-   |}
-];
+   |};
 
 let x = 22;

--- a/demo/universal/native/lib/Theme.re
+++ b/demo/universal/native/lib/Theme.re
@@ -1,5 +1,16 @@
-type align = [ | `start | `center | `end_];
-type justify = [ | `around | `between | `evenly | `start | `center | `end_];
+type align = [
+  | `start
+  | `center
+  | `end_
+];
+type justify = [
+  | `around
+  | `between
+  | `evenly
+  | `start
+  | `center
+  | `end_
+];
 
 module Media = {
   let onDesktop = rules => {

--- a/dune-project
+++ b/dune-project
@@ -45,7 +45,7 @@
   ; Dev dependencies
   (ocamlformat
    (and
-    (= 0.26.1)
+    (= 0.26.2)
     :with-test)) ; We use ocamlformat on the tests
   (ocaml-lsp-server :with-dev-setup)
 

--- a/dune-project
+++ b/dune-project
@@ -26,7 +26,7 @@
  (depends
   ; General system dependencies
   (ocaml (>= 5.0.0))
-  (reason (= 3.10.0))
+  (reason (>= 3.11.0))
   (melange (>= 3.0.0))
 
   ; Library dependencies

--- a/packages/promise/js/promise.re
+++ b/packages/promise/js/promise.re
@@ -14,8 +14,7 @@ let onUnhandledException =
     Js.Console.error(exn);
   });
 
-[%%mel.raw
-  {|
+{%%mel.raw |
 function PromiseBox(p) {
     this.nested = p;
 };
@@ -72,8 +71,7 @@ function catch_(promise, callback) {
 
     return promise.catch(safeCallback);
 };
-|}
-];
+|};
 
 module Js_ = {
   type t('a, 'e) = rejectable('a, 'e);

--- a/packages/promise/native/promise.re
+++ b/packages/promise/native/promise.re
@@ -39,7 +39,13 @@ module MutableList: MutableList = {
     mutable last: node('a),
   };
 
-  type list('a) = ref([ | `Empty | `NonEmpty(listEnds('a))]);
+  type list('a) =
+    ref(
+      [
+        | `Empty
+        | `NonEmpty(listEnds('a))
+      ],
+    );
 
   let create = () => ref(`Empty);
 
@@ -48,12 +54,24 @@ module MutableList: MutableList = {
   let append = (list, value) =>
     switch (list^) {
     | `Empty =>
-      let node = {previous: None, next: None, content: value};
-      list := `NonEmpty({first: node, last: node});
+      let node = {
+        previous: None,
+        next: None,
+        content: value,
+      };
+      list :=
+        `NonEmpty({
+          first: node,
+          last: node,
+        });
       node;
 
     | `NonEmpty(ends) =>
-      let node = {previous: Some(ends.last), next: None, content: value};
+      let node = {
+        previous: Some(ends.last),
+        next: None,
+        content: value,
+      };
       ends.last.next = Some(node);
       ends.last = node;
       node;

--- a/packages/server-reason-react-ppx/cram/external.t/run.t
+++ b/packages/server-reason-react-ppx/cram/external.t/run.t
@@ -1,5 +1,6 @@
   $ ../ppx.sh --output re input.re
   module MyPropIsOptionOptionBoolWithSig = {
-    [%ocaml.error
-     "externals aren't supported on server-reason-react. externals are used to bind to React components defined in JavaScript, in the server, that doesn't make sense. If you need to render this on the server, implement a placeholder or an empty element"];
+    [%%ocaml.error
+      "externals aren't supported on server-reason-react. externals are used to bind to React components defined in JavaScript, in the server, that doesn't make sense. If you need to render this on the server, implement a placeholder or an empty element"
+    ];
   };

--- a/packages/webapi/tests/Dom/Webapi__Dom__Element__test.re
+++ b/packages/webapi/tests/Dom/Webapi__Dom__Element__test.re
@@ -68,7 +68,13 @@ let _ = scrollIntoView(el);
 /*let _ = scrollIntoViewNoAlignToTop(el);*/
 let _ = scrollIntoViewNoAlignToTop(el);
 let _ =
-  scrollIntoViewWithOptions({"block": "end", "behavior": "smooth"}, el);
+  scrollIntoViewWithOptions(
+    {
+      "block": "end",
+      "behavior": "smooth",
+    },
+    el,
+  );
 let _ = setAttribute("href", "http://...", el);
 let _ = setAttributeNS("http://...", "foo", "bar", el);
 let _ = setPointerCapture(PointerEvent.pointerId(event), el);

--- a/packages/webapi/tests/Dom/Webapi__Dom__EventTarget__test.re
+++ b/packages/webapi/tests/Dom/Webapi__Dom__EventTarget__test.re
@@ -10,7 +10,11 @@ addEventListener("click", handleClick, target);
 addEventListenerWithOptions(
   "click",
   handleClick,
-  {"passive": true, "once": true, "capture": false},
+  {
+    "passive": true,
+    "once": true,
+    "capture": false,
+  },
   target,
 );
 addEventListenerUseCapture("click", handleClick, target);
@@ -18,7 +22,10 @@ removeEventListener("click", handleClick, target);
 removeEventListenerWithOptions(
   "click",
   handleClick,
-  {"passive": true, "capture": false},
+  {
+    "passive": true,
+    "capture": false,
+  },
   target,
 );
 removeEventListenerUseCapture("click", handleClick, target);
@@ -26,9 +33,12 @@ let _ = dispatchEvent(event, target);
 
 /* https://github.com/reasonml-community/bs-webapi-incubator/issues/103 */
 let customEvent =
-  CustomEvent.makeWithOptions("custom-event", {
-                                                "detail": {
-                                                  "test": "test",
-                                                },
-                                              });
+  CustomEvent.makeWithOptions(
+    "custom-event",
+    {
+      "detail": {
+        "test": "test",
+      },
+    },
+  );
 dispatchEvent(customEvent, target);

--- a/packages/webapi/tests/Dom/Webapi__Dom__GlobalEventHandlers__test.re
+++ b/packages/webapi/tests/Dom/Webapi__Dom__GlobalEventHandlers__test.re
@@ -6,14 +6,21 @@ let elm = document |> Document.createElement("strong");
 
 Element.addSelectionChangeEventListenerWithOptions(
   handleSelection,
-  {"passive": true, "once": true, "capture": false},
+  {
+    "passive": true,
+    "once": true,
+    "capture": false,
+  },
   elm,
 );
 Element.addSelectionChangeEventListenerUseCapture(handleSelection, elm);
 Element.removeSelectionChangeEventListener(handleSelection, elm);
 Element.removeSelectionChangeEventListenerWithOptions(
   handleSelection,
-  {"passive": true, "capture": false},
+  {
+    "passive": true,
+    "capture": false,
+  },
   elm,
 );
 Element.removeSelectionChangeEventListenerUseCapture(handleSelection, elm);
@@ -26,7 +33,11 @@ let htmlElm =
 
 HtmlElement.addSelectionChangeEventListenerWithOptions(
   handleSelection,
-  {"passive": true, "once": true, "capture": false},
+  {
+    "passive": true,
+    "once": true,
+    "capture": false,
+  },
   htmlElm,
 );
 HtmlElement.addSelectionChangeEventListenerUseCapture(
@@ -36,7 +47,10 @@ HtmlElement.addSelectionChangeEventListenerUseCapture(
 HtmlElement.removeSelectionChangeEventListener(handleSelection, htmlElm);
 HtmlElement.removeSelectionChangeEventListenerWithOptions(
   handleSelection,
-  {"passive": true, "capture": false},
+  {
+    "passive": true,
+    "capture": false,
+  },
   htmlElm,
 );
 HtmlElement.removeSelectionChangeEventListenerUseCapture(
@@ -49,7 +63,11 @@ let htmlDoc =
 
 HtmlDocument.addSelectionChangeEventListenerWithOptions(
   handleSelection,
-  {"passive": true, "once": true, "capture": false},
+  {
+    "passive": true,
+    "once": true,
+    "capture": false,
+  },
   htmlDoc,
 );
 HtmlDocument.addSelectionChangeEventListenerUseCapture(
@@ -59,7 +77,10 @@ HtmlDocument.addSelectionChangeEventListenerUseCapture(
 HtmlDocument.removeSelectionChangeEventListener(handleSelection, htmlDoc);
 HtmlDocument.removeSelectionChangeEventListenerWithOptions(
   handleSelection,
-  {"passive": true, "capture": false},
+  {
+    "passive": true,
+    "capture": false,
+  },
   htmlDoc,
 );
 HtmlDocument.removeSelectionChangeEventListenerUseCapture(
@@ -69,14 +90,21 @@ HtmlDocument.removeSelectionChangeEventListenerUseCapture(
 
 Window.addSelectionChangeEventListenerWithOptions(
   handleSelection,
-  {"passive": true, "once": true, "capture": false},
+  {
+    "passive": true,
+    "once": true,
+    "capture": false,
+  },
   window,
 );
 Window.addSelectionChangeEventListenerUseCapture(handleSelection, window);
 Window.removeSelectionChangeEventListener(handleSelection, window);
 Window.removeSelectionChangeEventListenerWithOptions(
   handleSelection,
-  {"passive": true, "capture": false},
+  {
+    "passive": true,
+    "capture": false,
+  },
   window,
 );
 Window.removeSelectionChangeEventListenerUseCapture(handleSelection, window);

--- a/server-reason-react.opam
+++ b/server-reason-react.opam
@@ -9,7 +9,7 @@ bug-reports: "https://github.com/ml-in-barcelona/server-reason-react/issues"
 depends: [
   "dune" {>= "3.9"}
   "ocaml" {>= "5.0.0"}
-  "reason" {= "3.10.0"}
+  "reason" {>= "3.11.0"}
   "melange" {>= "3.0.0"}
   "uucp" {>= "16.0.0"}
   "ppxlib" {> "0.23.0"}

--- a/server-reason-react.opam
+++ b/server-reason-react.opam
@@ -20,7 +20,7 @@ depends: [
   "uri" {>= "4.2.0"}
   "integers"
   "odoc" {with-doc}
-  "ocamlformat" {= "0.26.1" & with-test}
+  "ocamlformat" {= "0.26.2" & with-test}
   "ocaml-lsp-server" {with-dev-setup}
   "dream" {with-dev-setup}
   "melange-webapi" {with-dev-setup}


### PR DESCRIPTION
## Description

This PR updates the reason to 3.11.0 and higher and formats the files.
It attempts to solve the format issues on CI that required us to fix the reason to `3.10.0`.

@davesnx after I cleaned the opam cache and update to `3.11.0` I was able to run `make format` and see the output we have in this PR.

I have to say that one of the changes was strange to me, the change to raw:
```diff
- let%browser_only mockInitWebsocket = () => [%mel.raw
+ let%browser_only mockInitWebsocket = () =>
+  {%mel.raw |
    function mockInitWebsocket() {
      console.log("Load JS");
    }
- |}
- ];
+ |};
```
I don't know if we want to have or change this in some way.

## Why to have this PR?

In theory, this PR will let us continue without the reason dep blocked. 
And then let us, for example, to update `server-reason-react` on `styled-ppx`
<img width="1096" alt="Captura de Tela 2024-11-04 às 19 59 39" src="https://github.com/user-attachments/assets/9c378c73-2b5f-4b4c-b0a1-90de34887389">
