### PR TITLE
Implement toFixed function

### DIFF
--- a/packages/melange.js/Js.ml
+++ b/packages/melange.js/Js.ml
@@ -1628,7 +1628,12 @@ end = struct
   let isNaN float = Stdlib.Float.is_nan float
   let isFinite float = Stdlib.Float.is_finite float
   let toExponential ?digits:_ _ = notImplemented "Js.Float" "toExponential"
-  let toFixed ?digits:_ _ = notImplemented "Js.Float" "toFixed"
+
+  let toFixed ?(digits = 0) f =
+    if digits < 0 || digits > 100 then
+      raise (Failure "toFixed() digits argument must be between 0 and 100")
+    else Printf.sprintf "%.*f" digits f
+
   let toPrecision ?digits:_ _ = notImplemented "Js.Float" "toPrecision"
 
   let toString ?radix f =

--- a/packages/melange.js/Js.ml
+++ b/packages/melange.js/Js.ml
@@ -1624,31 +1624,54 @@ module Float : sig
 end = struct
   type t = float
 
-  let _NaN = Stdlib.Float.nan
-  let isNaN float = Stdlib.Float.is_nan float
+  module SpecialValues = struct
+    let _NaN = Stdlib.Float.nan
+    let isNaN float = Stdlib.Float.is_nan float
+
+    let fromString str =
+      match str with
+      | "NaN" -> _NaN
+      | "Infinity" -> infinity
+      | "-Infinity" -> neg_infinity
+      | _ -> raise (Failure "Invalid special value")
+
+    let toString = function
+      | t when isNaN t -> "NaN"
+      | t when t = infinity -> "Infinity"
+      | t when t = neg_infinity -> "-Infinity"
+      | _ -> raise (Failure "Invalid special value")
+  end
+
+  let _NaN = SpecialValues._NaN
+  let isNaN = SpecialValues.isNaN
   let isFinite float = Stdlib.Float.is_finite float
   let toExponential ?digits:_ _ = notImplemented "Js.Float" "toExponential"
 
   let toFixed ?(digits = 0) f =
-    if digits < 0 || digits > 100 then
-      raise (Failure "toFixed() digits argument must be between 0 and 100")
-    else Printf.sprintf "%.*f" digits f
+    try SpecialValues.toString f
+    with _ ->
+      if digits < 0 || digits > 100 then
+        raise (Failure "toFixed() digits argument must be between 0 and 100")
+      else Printf.sprintf "%.*f" digits f
 
   let toPrecision ?digits:_ _ = notImplemented "Js.Float" "toPrecision"
 
   let toString ?radix f =
-    match radix with
-    | None ->
-        (* round x rounds x to the nearest integer with ties (fractional values of 0.5) rounded away from zero, regardless of the current rounding direction. If x is an integer, +0., -0., nan, or infinite, x itself is returned.
+    try SpecialValues.toString f
+    with _ -> (
+      match radix with
+      | None ->
+          (* round x rounds x to the nearest integer with ties (fractional values of 0.5) rounded away from zero, regardless of the current rounding direction.
 
-           On 64-bit mingw-w64, this function may be emulated owing to a bug in the C runtime library (CRT) on this platform. *)
-        (* if round(f) == f, print the integer (since string_of_float 1.0 => "1.") *)
-        if Stdlib.Float.equal (Stdlib.Float.round f) f then
-          f |> int_of_float |> string_of_int
-        else Printf.sprintf "%g" f
-    | Some _ -> notImplemented "Js.Float" "toString ~radix"
+             On 64-bit mingw-w64, this function may be emulated owing to a bug in the C runtime library (CRT) on this platform. *)
+          (* if round(f) == f, print the integer (since string_of_float 1.0 => "1.") *)
+          if Stdlib.Float.equal (Stdlib.Float.round f) f then
+            f |> int_of_float |> string_of_int
+          else Printf.sprintf "%g" f
+      | Some _ -> notImplemented "Js.Float" "toString ~radix")
 
-  let fromString = Stdlib.float_of_string
+  let fromString str =
+    try SpecialValues.fromString str with _ -> Stdlib.float_of_string str
 end
 
 module Int : sig

--- a/packages/melange.js/Js.mli
+++ b/packages/melange.js/Js.mli
@@ -1284,8 +1284,6 @@ module Float : sig
     not_implemented "is not implemented in native under server-reason-react.js"]
 
   val toFixed : ?digits:int -> t -> string
-  [@@alert
-    not_implemented "is not implemented in native under server-reason-react.js"]
 
   val toPrecision : ?digits:int -> t -> string
   [@@alert

--- a/packages/melange.js/test.ml
+++ b/packages/melange.js/test.ml
@@ -570,6 +570,25 @@ let float_tests =
         assert_string (Js.Float.toString 80.) "80";
         assert_string (Js.Float.toString 80.0001) "80.0001";
         assert_string (Js.Float.toString 80.00000000001) "80");
+    test "toFixed" (fun () ->
+        assert_string (Js.Float.toFixed 12.3456) "12";
+        assert_string (Js.Float.toFixed 0.123456) "0";
+        assert_string (Js.Float.toFixed ~digits:20 0.) "0.00000000000000000000";
+        assert_string (Js.Float.toFixed ~digits:0 12.3456) "12";
+        assert_string (Js.Float.toFixed ~digits:0 (-12.)) "-12";
+        assert_string (Js.Float.toFixed ~digits:3 12.3456) "12.346";
+        (* assert_string (Js.Float.toFixed ~digits:0 1.2e34) "1.2e+34"; actual result in ocaml is "11999999999999999346902771844513792" *)
+        assert_string (Js.Float.toFixed ~digits:10 12.3456) "12.3456000000";
+        Alcotest.check_raises "Expected failure"
+          (Failure "toFixed() digits argument must be between 0 and 100")
+          (fun () ->
+            let _ = Js.Float.toFixed ~digits:(-1) 12. in
+            ());
+        Alcotest.check_raises "Expected failure"
+          (Failure "toFixed() digits argument must be between 0 and 100")
+          (fun () ->
+            let _ = Js.Float.toFixed ~digits:101 12. in
+            ()));
   ]
 
 let () =

--- a/packages/melange.js/test.ml
+++ b/packages/melange.js/test.ml
@@ -569,26 +569,60 @@ let float_tests =
         assert_string (Js.Float.toString 80.0) "80";
         assert_string (Js.Float.toString 80.) "80";
         assert_string (Js.Float.toString 80.0001) "80.0001";
-        assert_string (Js.Float.toString 80.00000000001) "80");
+        (* assert_string (Js.Float.toString 80.00000000001) "80.00000000001"; JS/Melange outputs "80.00000000001" but ocaml outputs "80." *)
+        assert_string (Js.Float.toString Stdlib.Float.nan) "NaN";
+        assert_string (Js.Float.toString Stdlib.Float.infinity) "Infinity";
+        assert_string (Js.Float.toString Stdlib.Float.neg_infinity) "-Infinity");
+    test "fromString" (fun () ->
+        assert_float (Js.Float.fromString "0.5") 0.5;
+        assert_float (Js.Float.fromString "80") 80.;
+        assert_float (Js.Float.fromString "80.0001") 80.0001;
+        (* assert_float (Js.Float.fromString "80.00000000001") 80.00000000001; JS/Melange outputs 80.00000000001 but ocaml outputs 80. *)
+        assert_float (Js.Float.fromString "NaN") Stdlib.Float.nan;
+        assert_float (Js.Float.fromString "Infinity") Stdlib.Float.infinity;
+        assert_float (Js.Float.fromString "-Infinity") Stdlib.Float.neg_infinity);
     test "toFixed" (fun () ->
         assert_string (Js.Float.toFixed 12.3456) "12";
-        assert_string (Js.Float.toFixed 0.123456) "0";
         assert_string (Js.Float.toFixed ~digits:20 0.) "0.00000000000000000000";
-        assert_string (Js.Float.toFixed ~digits:0 12.3456) "12";
         assert_string (Js.Float.toFixed ~digits:0 (-12.)) "-12";
+        assert_string (Js.Float.toFixed ~digits:0 Stdlib.Float.nan) "NaN";
+        assert_string
+          (Js.Float.toFixed ~digits:0 1000000000000000128.)
+          "1000000000000000128";
         assert_string (Js.Float.toFixed ~digits:3 12.3456) "12.346";
-        (* assert_string (Js.Float.toFixed ~digits:0 1.2e34) "1.2e+34"; actual result in ocaml is "11999999999999999346902771844513792" *)
-        assert_string (Js.Float.toFixed ~digits:10 12.3456) "12.3456000000";
+        assert_string
+          (Js.Float.toFixed ~digits:50 0.3)
+          "0.29999999999999998889776975374843459576368331909180";
         Alcotest.check_raises "Expected failure"
           (Failure "toFixed() digits argument must be between 0 and 100")
           (fun () ->
             let _ = Js.Float.toFixed ~digits:(-1) 12. in
             ());
-        Alcotest.check_raises "Expected failure"
+        assert_string (Js.Float.toFixed ~digits:2 12.345) "12.35";
+        assert_string (Js.Float.toFixed ~digits:2 12.344) "12.34";
+        assert_string (Js.Float.toFixed ~digits:1 0.05) "0.1";
+        assert_string
+          (Js.Float.toFixed ~digits:5 1e20)
+          "100000000000000000000.00000";
+        assert_string (Js.Float.toFixed ~digits:5 1e-20) "0.00000";
+        assert_string (Js.Float.toFixed ~digits:10 1e-10) "0.0000000001";
+        assert_string
+          (Js.Float.toFixed ~digits:100 0.1)
+          "0.1000000000000000055511151231257827021181583404541015625000000000000000000000000000000000000000000000";
+        assert_string (Js.Float.toFixed ~digits:0 0.99) "1";
+        assert_string (Js.Float.toFixed ~digits:5 Float.infinity) "Infinity";
+        assert_string
+          (Js.Float.toFixed ~digits:5 Float.neg_infinity)
+          "-Infinity";
+        assert_string (Js.Float.toFixed ~digits:2 (-12.3456)) "-12.35";
+        assert_string (Js.Float.toFixed ~digits:4 0.) "0.0000";
+        (* assert_string (Js.Float.toFixed ~digits:0 1.2e34) "1.2e+34"; JS/Melange outputs "1.2e+34" but ocaml outputs "11999999999999999346902771844513792" *)
+        Alcotest.check_raises "Expected failure for negative digits"
           (Failure "toFixed() digits argument must be between 0 and 100")
-          (fun () ->
-            let _ = Js.Float.toFixed ~digits:101 12. in
-            ()));
+          (fun () -> ignore (Js.Float.toFixed ~digits:(-1) 12.34));
+        Alcotest.check_raises "Expected failure for exceeding digits limit"
+          (Failure "toFixed() digits argument must be between 0 and 100")
+          (fun () -> ignore (Js.Float.toFixed ~digits:101 12.34)));
   ]
 
 let () =


### PR DESCRIPTION
## Description

This `PR` adds:
- the `toFixed` function.
- a way to handle NaN, Infinity, and -Infinity

@davesnx I was creating `toFixed` and realized that returning `"nan"`, `"infinity"` and `"neg_infinity"` could lead to bugs as JS expects those values as `"NaN"`, `"Infinity"` and `"-Infinity"`. Issues like: `Js.Float.fromString` on melange with `"infinity"` outputs `NaN` and with `"Infinity"` outputs `Infinity`. [Playground](https://melange.re/unstable/playground/?language=OCaml&code=SnMubG9nKEpzLkZsb2F0LmZyb21TdHJpbmcgIkluZmluaXR5Iik7CkpzLmxvZyhKcy5GbG9hdC5mcm9tU3RyaW5nICJpbmZpbml0eSIp&live=off)

Then I would like to hear about it this change.

## toFixed

It behaves as JS.
- if no `digits` is provided, the default value is 0
- The `digits` arg cannot be greater than 100 and less than 0
- `nan` outputs `NaN`, `infinity` outputs `Infinity` and neg_infinity outputs `-Infinity`

## Float.fromString and Float.toString

- fromString can handle `"NaN"`, `"Infinity"` and `"-Infinity"`
- toString outputs `"NaN"`, `"Infinity"` and `"-Infinity"` for `nan`, `infinity` and `neg_infinity`

## Trick cases that need further attention:

- `Js.Float.toString 80.00000000001`: JS/Melange outputs "80.00000000001" but ocaml outputs "80."
- `Js.Float.fromString "80.00000000001"`: JS/Melange outputs 80.00000000001 but ocaml outputs 80.
- `Js.Float.toFixed ~digits:0 1.2e34` JS/Melange outputs "1.2e+34" but ocaml outputs "11999999999999999346902771844513792"