### PR TITLE
Move ppx transformation to function body (not last expression)

### DIFF
--- a/packages/server-reason-react-ppx/cram/component.t/input.re
+++ b/packages/server-reason-react-ppx/cram/component.t/input.re
@@ -81,3 +81,25 @@ module Async_component = {
 };
 
 let a = <Async_component> <div /> </Async_component>;
+
+module Sequence = {
+  [@react.component]
+  let make = (~lola) => {
+    let (state, setState) = React.useState(lola);
+
+    React.useEffect(() => {
+      setState(lola);
+      None;
+    });
+
+    <div> {React.string(state)} </div>;
+  };
+};
+
+module Use_context = {
+  [@react.component]
+  let make = () => {
+    let captured = React.useContext(Context.value);
+    <div> {React.string(captured)} </div>;
+  };
+};

--- a/packages/server-reason-react-ppx/cram/component.t/run.t
+++ b/packages/server-reason-react-ppx/cram/component.t/run.t
@@ -27,9 +27,9 @@ We need to output ML syntax here, otherwise refmt could not parse it.
   
   module Onclick_handler_button = struct
     let make ?key:(_ : string option) ~name ?isDisabled () =
-      let onClick event = Js.log event in
       React.Upper_case_component
         (fun () ->
+          let onClick event = Js.log event in
           React.createElement "button"
             (Stdlib.List.filter_map Fun.id
                [
@@ -123,3 +123,22 @@ We need to output ML syntax here, otherwise refmt could not parse it.
   end
   
   let a = Async_component.make ~children:(React.createElement "div" [] []) ()
+  
+  module Sequence = struct
+    let make ?key:(_ : string option) ~lola () =
+      React.Upper_case_component
+        (fun () ->
+          let state, setState = React.useState lola in
+          React.useEffect (fun () ->
+              setState lola;
+              None);
+          React.createElement "div" [] [ React.string state ])
+  end
+  
+  module Use_context = struct
+    let make ?key:(_ : string option) () =
+      React.Upper_case_component
+        (fun () ->
+          let captured = React.useContext Context.value in
+          React.createElement "div" [] [ React.string captured ])
+  end

--- a/packages/server-reason-react-ppx/cram/functor.t/run.t
+++ b/packages/server-reason-react-ppx/cram/functor.t/run.t
@@ -9,6 +9,8 @@ We need to output ML syntax here, otherwise refmt could not parse it.
     let x = M.x + 1
   
     let make ?key:(_ : string option) ~a ~b () =
-      print_endline "This function should be named `Test$Func`" M.x;
-      React.Upper_case_component (fun () -> React.createElement "div" [] [])
+      React.Upper_case_component
+        (fun () ->
+          print_endline "This function should be named `Test$Func`" M.x;
+          React.createElement "div" [] [])
   end

--- a/packages/server-reason-react-ppx/server_reason_react_ppx.ml
+++ b/packages/server-reason-react-ppx/server_reason_react_ppx.ml
@@ -449,11 +449,9 @@ let rec transform_function_with_warning expression =
       { expression with pexp_desc = Pexp_sequence (wrapperExpression, exp) }
   | _ -> expression
 
-let transofrm_last_expression expr fn =
+let transform_last_expression expr fn =
   let rec inner expr =
     match expr.pexp_desc with
-    | Pexp_sequence (expr, sequence) -> pexp_sequence ~loc:expr.pexp_loc expr (inner sequence)
-    | Pexp_let (flag, patt, expression) -> pexp_let ~loc:expr.pexp_loc flag patt (inner expression)
     | Pexp_fun (label, def, patt, expression) -> pexp_fun ~loc:expr.pexp_loc label def patt (inner expression)
     | _ -> fn expr
   in
@@ -475,7 +473,7 @@ let make_value_binding binding wrapping =
   (* Append key argument since we want to allow users of this component to set key
      (and assign it to _ since it shouldn't be used) *)
   let body_expression =
-    pexp_fun ~loc:ghost_loc key_arg default_value key_pattern (transofrm_last_expression binding_expr wrapping)
+    pexp_fun ~loc:ghost_loc key_arg default_value key_pattern (transform_last_expression binding_expr wrapping)
   in
   Ast_helper.Vb.mk ~loc name body_expression
 


### PR DESCRIPTION
This PR fixes https://github.com/ml-in-barcelona/server-reason-react/issues/191

It moves the wrapping of `React.upper_case_ and React.async_` as a first expression on the make binding. Before this was added as the last expression found (if it was a sequence). 

The bug appears when `useContext` is used, since the execution of this hook would be in a different execution order from the rest of the component.