### PR TITLE
Use the right extension syntax on promise.js

### DIFF
--- a/packages/promise/js/promise.re
+++ b/packages/promise/js/promise.re
@@ -14,7 +14,7 @@ let onUnhandledException =
     Js.Console.error(exn);
   });
 
-[%mel.raw
+[%%mel.raw
   {|
 function PromiseBox(p) {
     this.nested = p;


### PR DESCRIPTION
## Description

The usage of `%mel.raw` on promise.js breaks the js code.
This bug was added here: https://github.com/ml-in-barcelona/server-reason-react/commit/ea16c107cd41a2e9d01dff358239eec37046951f