### PR TITLE
RSC syntax ppx

### DIFF
--- a/demo/client/runtime-with-client.jsx
+++ b/demo/client/runtime-with-client.jsx
@@ -1,5 +1,5 @@
 window.__webpack_require__ = (id) => {
-	console.log("REQUIRE ---");
+	console.log("__webpack_require__");
 	const component = window.__client_manifest_map[id];
 	console.log(id);
 	console.log(component);
@@ -16,17 +16,18 @@ const ReactServerDOM = require("react-server-dom-webpack/client");
 window.__client_manifest_map = {};
 
 const register = (name, render) => {
+	console.log("Client ref registered:", name);
 	window.__client_manifest_map[name] = render;
 };
 
 register(
   "Counter",
-  React.lazy(() => import("./app/demo/universal/js/Counter.js"))
+  React.lazy(() => import("./app/demo/universal/js/Counter.js").then(module => ({ default: module.make })))
 );
 
 register(
 	"Note_editor",
-	React.lazy(() => import("./app/demo/universal/js/Note_editor.js")),
+	React.lazy(() => import("./app/demo/universal/js/Note_editor.js").then(module => ({ default: module.make }))),
 );
 
 /* register(

--- a/demo/universal/native/lib/Counter.re
+++ b/demo/universal/native/lib/Counter.re
@@ -1,12 +1,3 @@
-let props_to_json = (~initial, ()) => {
-  switch%platform (Runtime.platform) {
-  | Server => [("initial", React.Json(`Int(initial)))]
-  | Client =>
-    Js.log(initial);
-    [];
-  };
-};
-
 [@react.component]
 [@react.client.component]
 let make = (~initial: int) => {

--- a/demo/universal/native/lib/Counter.re
+++ b/demo/universal/native/lib/Counter.re
@@ -1,67 +1,39 @@
-[@warning "-27"];
+let props_to_json = (~initial, ()) => {
+  switch%platform (Runtime.platform) {
+  | Server => [("initial", React.Json(`Int(initial)))]
+  | Client =>
+    Js.log(initial);
+    [];
+  };
+};
 
 [@react.component]
-let make = (~initial: int) =>
-  switch%platform (Runtime.platform) {
-  | Server =>
-    React.Client_component({
-      import_module: "Counter",
-      import_name: "",
-      props: [("initial", React.Json(`Int(initial)))],
-      client: {
-        let (state, setCount) = RR.useStateValue(initial);
+[@react.client.component]
+let make = (~initial: int) => {
+  let (state, setCount) = RR.useStateValue(initial);
 
-        let onClick = _event => {
-          setCount(state + 1);
-        };
-
-        <div className={Theme.text(Theme.Color.white)}>
-          <Spacer bottom=0>
-            <div
-              className={Cx.make([
-                "flex",
-                "justify-items-end",
-                "items-center",
-                "gap-4",
-              ])}>
-              <p className={Cx.make(["m-0", "text-3xl", "font-bold"])}>
-                {React.string("Counter")}
-              </p>
-              <button
-                onClick
-                className="font-mono border-2 py-1 px-2 rounded-lg bg-yellow-950 border-yellow-700 text-yellow-200">
-                {React.string(Int.to_string(state))}
-              </button>
-            </div>
-          </Spacer>
-        </div>;
-      },
-    })
-  | Client =>
-    let (state, setCount) = RR.useStateValue(initial);
-
-    let onClick = _event => {
-      setCount(state + 1);
-    };
-
-    <div className={Theme.text(Theme.Color.white)}>
-      <Spacer bottom=0>
-        <div
-          className={Cx.make([
-            "flex",
-            "justify-items-end",
-            "items-center",
-            "gap-4",
-          ])}>
-          <p className={Cx.make(["m-0", "text-3xl", "font-bold"])}>
-            {React.string("Counter")}
-          </p>
-          <button
-            onClick
-            className="font-mono border-2 py-1 px-2 rounded-lg bg-yellow-950 border-yellow-700 text-yellow-200">
-            {React.string(Int.to_string(state))}
-          </button>
-        </div>
-      </Spacer>
-    </div>;
+  let onClick = _event => {
+    setCount(state + 1);
   };
+
+  <div className={Theme.text(Theme.Color.white)}>
+    <Spacer bottom=0>
+      <div
+        className={Cx.make([
+          "flex",
+          "justify-items-end",
+          "items-center",
+          "gap-4",
+        ])}>
+        <p className={Cx.make(["m-0", "text-3xl", "font-bold"])}>
+          {React.string("Counter")}
+        </p>
+        <button
+          onClick
+          className="font-mono border-2 py-1 px-2 rounded-lg bg-yellow-950 border-yellow-700 text-yellow-200">
+          {React.string(Int.to_string(state))}
+        </button>
+      </div>
+    </Spacer>
+  </div>;
+};

--- a/demo/universal/native/lib/Counter.re
+++ b/demo/universal/native/lib/Counter.re
@@ -1,5 +1,5 @@
+[@client]
 [@react.component]
-[@react.client.component]
 let make = (~initial: int) => {
   let (state, setCount) = RR.useStateValue(initial);
 

--- a/demo/universal/native/lib/Counter.re
+++ b/demo/universal/native/lib/Counter.re
@@ -1,34 +1,5 @@
 [@warning "-27"];
 
-let make = (~initial) => {
-  let (state, setCount) = RR.useStateValue(initial);
-
-  let onClick = _event => {
-    setCount(state + 1);
-  };
-
-  <div className={Theme.text(Theme.Color.white)}>
-    <Spacer bottom=0>
-      <div
-        className={Cx.make([
-          "flex",
-          "justify-items-end",
-          "items-center",
-          "gap-4",
-        ])}>
-        <p className={Cx.make(["m-0", "text-3xl", "font-bold"])}>
-          {React.string("Counter")}
-        </p>
-        <button
-          onClick
-          className="font-mono border-2 py-1 px-2 rounded-lg bg-yellow-950 border-yellow-700 text-yellow-200">
-          {React.string(Int.to_string(state))}
-        </button>
-      </div>
-    </Spacer>
-  </div>;
-};
-
 [@react.component]
 let make = (~initial: int) =>
   switch%platform (Runtime.platform) {
@@ -37,9 +8,60 @@ let make = (~initial: int) =>
       import_module: "Counter",
       import_name: "",
       props: [("initial", React.Json(`Int(initial)))],
-      client: make(~initial),
-    })
-  | Client => make(~initial)
-  };
+      client: {
+        let (state, setCount) = RR.useStateValue(initial);
 
-let default = make;
+        let onClick = _event => {
+          setCount(state + 1);
+        };
+
+        <div className={Theme.text(Theme.Color.white)}>
+          <Spacer bottom=0>
+            <div
+              className={Cx.make([
+                "flex",
+                "justify-items-end",
+                "items-center",
+                "gap-4",
+              ])}>
+              <p className={Cx.make(["m-0", "text-3xl", "font-bold"])}>
+                {React.string("Counter")}
+              </p>
+              <button
+                onClick
+                className="font-mono border-2 py-1 px-2 rounded-lg bg-yellow-950 border-yellow-700 text-yellow-200">
+                {React.string(Int.to_string(state))}
+              </button>
+            </div>
+          </Spacer>
+        </div>;
+      },
+    })
+  | Client =>
+    let (state, setCount) = RR.useStateValue(initial);
+
+    let onClick = _event => {
+      setCount(state + 1);
+    };
+
+    <div className={Theme.text(Theme.Color.white)}>
+      <Spacer bottom=0>
+        <div
+          className={Cx.make([
+            "flex",
+            "justify-items-end",
+            "items-center",
+            "gap-4",
+          ])}>
+          <p className={Cx.make(["m-0", "text-3xl", "font-bold"])}>
+            {React.string("Counter")}
+          </p>
+          <button
+            onClick
+            className="font-mono border-2 py-1 px-2 rounded-lg bg-yellow-950 border-yellow-700 text-yellow-200">
+            {React.string(Int.to_string(state))}
+          </button>
+        </div>
+      </Spacer>
+    </div>;
+  };

--- a/demo/universal/native/lib/Note_editor.re
+++ b/demo/universal/native/lib/Note_editor.re
@@ -49,5 +49,3 @@ let make = (~title, ~body) =>
     })
   | Client => make(~title, ~body)
   };
-
-let default = make;

--- a/demo/universal/native/lib/Note_editor.re
+++ b/demo/universal/native/lib/Note_editor.re
@@ -1,5 +1,7 @@
 [@warning "-27"];
 
+[@client]
+[@react.component]
 let make = (~title: string, ~body: string) => {
   let (title, setTitle) = RR.useStateValue(title);
   let (body, setBody) = RR.useStateValue(body);
@@ -33,19 +35,3 @@ let make = (~title: string, ~body: string) => {
     />
   </form>;
 };
-
-[@react.component]
-let make = (~title, ~body) =>
-  switch%platform (Runtime.platform) {
-  | Server =>
-    React.Client_component({
-      import_module: "Note_editor",
-      import_name: "",
-      props: [
-        ("title", React.Json(`String(title))),
-        ("body", React.Json(`String(body))),
-      ],
-      client: make(~title, ~body),
-    })
-  | Client => make(~title, ~body)
-  };

--- a/packages/reactDom/src/ReactDOM.ml
+++ b/packages/reactDom/src/ReactDOM.ml
@@ -51,7 +51,7 @@ let render_to_string ~mode element =
     | Async_component _component ->
         raise
           (Invalid_argument
-             "Asyncronous components can't be rendered to static markup, since rendering is syncronous. Please use \
+             "Async components can't be rendered to static markup, since rendering is synchronous. Please use \
               `renderToStream` instead.")
     | Lower_case_element { key = _; tag; attributes; children } ->
         is_root.contents <- false;

--- a/packages/reactDom/test/test_renderToStaticMarkup.ml
+++ b/packages/reactDom/test/test_renderToStaticMarkup.ml
@@ -280,7 +280,7 @@ let async_component () =
   in
   Alcotest.check_raises "Expected invalid argument"
     (Invalid_argument
-       "Asyncronous components can't be rendered to static markup, since rendering is syncronous. Please use \
+       "Async components can't be rendered to static markup, since rendering is synchronous. Please use \
         `renderToStream` instead.")
     raises
 

--- a/packages/server-reason-react-ppx/cram/client.t/input.re
+++ b/packages/server-reason-react-ppx/cram/client.t/input.re
@@ -1,0 +1,18 @@
+module Sequence = {
+  let props_to_json = (~lola: int, ()) => [
+    ("lola", React.Json(`Int(lola))),
+  ];
+
+  [@react.component]
+  [@react.client.component]
+  let make = (~lola: int) => {
+    let (state, setState) = React.useState(lola);
+
+    React.useEffect(() => {
+      setState(lola);
+      None;
+    });
+
+    <div> {React.string(state)} </div>;
+  };
+};

--- a/packages/server-reason-react-ppx/cram/client.t/input.re
+++ b/packages/server-reason-react-ppx/cram/client.t/input.re
@@ -1,8 +1,4 @@
 module Sequence = {
-  let props_to_json = (~lola: int, ()) => [
-    ("lola", React.Json(`Int(lola))),
-  ];
-
   [@react.component]
   [@react.client.component]
   let make = (~lola: int) => {

--- a/packages/server-reason-react-ppx/cram/client.t/input.re
+++ b/packages/server-reason-react-ppx/cram/client.t/input.re
@@ -1,5 +1,5 @@
 module Prop_with_many_annotation = {
-  [@react.client.component]
+  [@client]
   let make =
       (
         ~prop: int,
@@ -14,17 +14,17 @@ module Prop_with_many_annotation = {
 };
 
 module Prop_without_annotation = {
-  [@react.client.component]
+  [@client]
   let make = (~prop_without_annotation) => React.null;
 };
 
 module Prop_with_unsupported_annotation = {
-  [@react.client.component]
+  [@client]
   let make = (~underscore: _, ~alpha_types: 'a) => React.null;
 };
 
 module Prop_with_annotation_that_need_to_be_type_alias = {
-  [@react.client.component]
+  [@client]
   let make =
       (
         ~polyvariants: [
@@ -35,7 +35,7 @@ module Prop_with_annotation_that_need_to_be_type_alias = {
 };
 
 module Prop_with_unknown_annotation = {
-  [@react.client.component]
+  [@client]
   let make =
       (
         ~lident: lola,

--- a/packages/server-reason-react-ppx/cram/client.t/input.re
+++ b/packages/server-reason-react-ppx/cram/client.t/input.re
@@ -1,14 +1,46 @@
-module Sequence = {
-  [@react.component]
+module Prop_with_many_annotation = {
   [@react.client.component]
-  let make = (~lola: int) => {
-    let (state, setState) = React.useState(lola);
+  let make =
+      (
+        ~prop: int,
+        ~lola: list(int),
+        ~mona: array(float),
+        ~lolo: string,
+        ~lili: bool,
+        ~lulu: float,
+        ~tuple2: (int, int),
+        ~tuple3: (int, string, float),
+      ) => React.null;
+};
 
-    React.useEffect(() => {
-      setState(lola);
-      None;
-    });
+module Prop_without_annotation = {
+  [@react.client.component]
+  let make = (~prop_without_annotation) => React.null;
+};
 
-    <div> {React.string(state)} </div>;
-  };
+module Prop_with_unsupported_annotation = {
+  [@react.client.component]
+  let make = (~underscore: _, ~alpha_types: 'a) => React.null;
+};
+
+module Prop_with_annotation_that_need_to_be_type_alias = {
+  [@react.client.component]
+  let make =
+      (
+        ~polyvariants: [
+           | `A
+           | `B
+         ],
+      ) => React.null;
+};
+
+module Prop_with_unknown_annotation = {
+  [@react.client.component]
+  let make =
+      (
+        ~lident: lola,
+        ~ldotlident: Module.lola,
+        ~ldotdotlident: Module.Inner.lola,
+        ~lapply: Label.t(int, string),
+      ) => React.null;
 };

--- a/packages/server-reason-react-ppx/cram/client.t/run.t
+++ b/packages/server-reason-react-ppx/cram/client.t/run.t
@@ -77,7 +77,7 @@
             "underscore",
             React.Json(
               [%ocaml.error
-                "server-reason-react: '_' annotation is not valid as a client prop"
+                "server-reason-react: '_' annotations aren't supported in client components. Try using a type definition with a json encoder but there's no guarantee that it will work. Open an issue if you need it."
               ],
             ),
           ),
@@ -109,7 +109,7 @@
             "polyvariants",
             React.Json(
               [%ocaml.error
-                "server-reason-react: inline types such as polyvariants, need to be a type with a json encoder 'to_json'."
+                "server-reason-react: inline types such as polyvariants, need to be a type definition with a json encoder. If the type is named 't' the encoder should be named 't_to_json', if the type is named 'foo' the encoder should be named 'foo_to_json'."
               ],
             ),
           ),

--- a/packages/server-reason-react-ppx/cram/client.t/run.t
+++ b/packages/server-reason-react-ppx/cram/client.t/run.t
@@ -1,0 +1,21 @@
+
+  $ ../ppx.sh --output re input.re
+  module Sequence = {
+    let props_to_json = (~lola: int, ()) => [
+      ("lola", React.Json(`Int(lola))),
+    ];
+    let make = (~key as _: option(string)=?, ~lola: int, ()) =>
+      React.Client_component({
+        import_module: __MODULE__,
+        import_name: "",
+        props: props_to_json(~lola, ()),
+        client: {
+          let (state, setState) = React.useState(lola);
+          React.useEffect(() => {
+            setState(lola);
+            None;
+          });
+          React.createElement("div", [], [React.string(state)]);
+        },
+      });
+  };

--- a/packages/server-reason-react-ppx/cram/client.t/run.t
+++ b/packages/server-reason-react-ppx/cram/client.t/run.t
@@ -1,22 +1,11 @@
 
   $ ../ppx.sh --output re input.re
   module Sequence = {
-    let props_to_json = (~lola: int, ()) => [
-      ("lola", React.Json(`Int(lola))),
-    ];
     let make = (~key as _: option(string)=?, ~lola: int, ()) =>
       React.Client_component({
         import_module: __MODULE__,
         import_name: "",
-        props: [
-          (
-            "lola",
-            {
-              let json = [%to_json: int](lola);
-              React.Json(json);
-            },
-          ),
-        ],
+        props: [("lola", React.Json(`Int(lola)))],
         client: {
           let (state, setState) = React.useState(lola);
           React.useEffect(() => {

--- a/packages/server-reason-react-ppx/cram/client.t/run.t
+++ b/packages/server-reason-react-ppx/cram/client.t/run.t
@@ -8,7 +8,15 @@
       React.Client_component({
         import_module: __MODULE__,
         import_name: "",
-        props: props_to_json(~lola, ()),
+        props: [
+          (
+            "lola",
+            {
+              let json = [%to_json: int](lola);
+              React.Json(json);
+            },
+          ),
+        ],
         client: {
           let (state, setState) = React.useState(lola);
           React.useEffect(() => {

--- a/packages/server-reason-react-ppx/cram/client.t/run.t
+++ b/packages/server-reason-react-ppx/cram/client.t/run.t
@@ -137,7 +137,7 @@
             "ldotdotlident",
             React.Json(Module.Inner.lola_to_json(ldotdotlident)),
           ),
-          ("lapply", React.Json(Label.t_to_json(lapply))),
+          ("lapply", React.Json(Label.to_json(lapply))),
         ],
         client: React.null,
       });

--- a/packages/server-reason-react-ppx/cram/client.t/run.t
+++ b/packages/server-reason-react-ppx/cram/client.t/run.t
@@ -1,18 +1,144 @@
 
   $ ../ppx.sh --output re input.re
-  module Sequence = {
-    let make = (~key as _: option(string)=?, ~lola: int, ()) =>
+  module Prop_with_many_annotation = {
+    let make =
+        (
+          ~key as _: option(string)=?,
+          ~prop: int,
+          ~lola: list(int),
+          ~mona: array(float),
+          ~lolo: string,
+          ~lili: bool,
+          ~lulu: float,
+          ~tuple2: (int, int),
+          ~tuple3: (int, string, float),
+          (),
+        ) =>
       React.Client_component({
         import_module: __MODULE__,
         import_name: "",
-        props: [("lola", React.Json(`Int(lola)))],
-        client: {
-          let (state, setState) = React.useState(lola);
-          React.useEffect(() => {
-            setState(lola);
-            None;
-          });
-          React.createElement("div", [], [React.string(state)]);
-        },
+        props: [
+          ("prop", React.Json(`Int(prop))),
+          ("lola", React.Json(`List(Stdlib.List.map(x => `Int(x), lola)))),
+          (
+            "mona",
+            React.Json(
+              `List(
+                Stdlib.Array.to_list(Stdlib.Array.map(x => `Float(x), mona)),
+              ),
+            ),
+          ),
+          ("lolo", React.Json(`String(lolo))),
+          ("lili", React.Json(`Bool(lili))),
+          ("lulu", React.Json(`Float(lulu))),
+          (
+            "tuple2",
+            React.Json(
+              {
+                let (x0, x1) = tuple2;
+                `List([`Int(x0), `Int(x1)]);
+              },
+            ),
+          ),
+          (
+            "tuple3",
+            React.Json(
+              {
+                let (x0, x1, x2) = tuple3;
+                `List([`Int(x0), `String(x1), `Float(x2)]);
+              },
+            ),
+          ),
+        ],
+        client: React.null,
+      });
+  };
+  module Prop_without_annotation = {
+    let make = (~key as _: option(string)=?, ~prop_without_annotation, ()) =>
+      React.Client_component({
+        import_module: __MODULE__,
+        import_name: "",
+        props: [
+          [%ocaml.error
+            "server-reason-react: client components need type annotations. Missing annotation for 'prop_without_annotation'"
+          ],
+        ],
+        client: React.null,
+      });
+  };
+  module Prop_with_unsupported_annotation = {
+    let make =
+        (~key as _: option(string)=?, ~underscore: _, ~alpha_types: 'a, ()) =>
+      React.Client_component({
+        import_module: __MODULE__,
+        import_name: "",
+        props: [
+          (
+            "underscore",
+            React.Json(
+              [%ocaml.error
+                "server-reason-react: '_' annotation is not valid as a client prop"
+              ],
+            ),
+          ),
+          (
+            "alpha_types",
+            React.Json(
+              [%ocaml.error "server-reason-react: unsupported type: 'a"],
+            ),
+          ),
+        ],
+        client: React.null,
+      });
+  };
+  module Prop_with_annotation_that_need_to_be_type_alias = {
+    let make =
+        (
+          ~key as _: option(string)=?,
+          ~polyvariants: [
+             | `A
+             | `B
+           ],
+          (),
+        ) =>
+      React.Client_component({
+        import_module: __MODULE__,
+        import_name: "",
+        props: [
+          (
+            "polyvariants",
+            React.Json(
+              [%ocaml.error
+                "server-reason-react: inline types such as polyvariants, need to be a type with a json encoder 'to_json'."
+              ],
+            ),
+          ),
+        ],
+        client: React.null,
+      });
+  };
+  module Prop_with_unknown_annotation = {
+    let make =
+        (
+          ~key as _: option(string)=?,
+          ~lident: lola,
+          ~ldotlident: Module.lola,
+          ~ldotdotlident: Module.Inner.lola,
+          ~lapply: Label.t(int, string),
+          (),
+        ) =>
+      React.Client_component({
+        import_module: __MODULE__,
+        import_name: "",
+        props: [
+          ("lident", React.Json(lola_to_json(lident))),
+          ("ldotlident", React.Json(Module.lola_to_json(ldotlident))),
+          (
+            "ldotdotlident",
+            React.Json(Module.Inner.lola_to_json(ldotdotlident)),
+          ),
+          ("lapply", React.Json(Label.t_to_json(lapply))),
+        ],
+        client: React.null,
       });
   };

--- a/packages/server-reason-react-ppx/cram/dune
+++ b/packages/server-reason-react-ppx/cram/dune
@@ -1,6 +1,11 @@
 (cram
  (package server-reason-react)
- (deps standalone.exe %{bin:refmt} %{bin:ocamlformat} ppx.sh))
+ (deps
+  (package server-reason-react)
+  standalone.exe
+  %{bin:refmt}
+  %{bin:ocamlformat}
+  ppx.sh))
 
 (executable
  (name standalone)


### PR DESCRIPTION
- Add `[@client]`
- Add encoding based on type annotations of props
- Fix demo using the new ppx
- Use `import(...).then(module => ({ default: module.make })))` for the demo and remove the `let default` on each client component