### PR TITLE
Create server_actions ppx

### DIFF
--- a/demo/server/server.re
+++ b/demo/server/server.re
@@ -27,6 +27,7 @@ let server =
         Pages.SinglePageRSC.handler,
       ),
       Dream.get(Router.demoRouter, Pages.RouterRSC.handler),
+      ...SRRServer.get_action_routes(),
     ]),
   );
 

--- a/demo/universal/native/lib/Counter.re
+++ b/demo/universal/native/lib/Counter.re
@@ -1,10 +1,22 @@
 open Ppx_deriving_json_runtime.Primitives;
 
+[@react.server.action]
+let onClickServerAction =
+    (~foo as a: string, ~bar: int): Js.Promise.t(string) => {
+  Js.Promise.resolve(a ++ string_of_int(bar));
+};
+
 [@react.client.component]
 let make = (~initial: int) => {
   let (state, setCount) = RR.useStateValue(initial);
 
   let onClick = _event => {
+    onClickServerAction(~foo="foo", ~bar=1)
+    |> Js.Promise.then_(result => {
+         Js.log("############" ++ result);
+         Js.Promise.resolve();
+       })
+    |> ignore;
     setCount(state + 1);
   };
 

--- a/demo/universal/native/lib/SRRServer.re
+++ b/demo/universal/native/lib/SRRServer.re
@@ -1,0 +1,25 @@
+// Defines a custom base route for the actions
+let baseRoute = Some("/api/actions/");
+
+// Defines the functions to adapt the server actions to the server
+[@platform native]
+include {
+          let actionRoutes = ref([]);
+
+          let register_action = (~handler, ~route) => {
+            actionRoutes :=
+              [
+                Dream.post(
+                  route,
+                  req => {
+                    let%lwt body = Dream.body(req);
+                    let%lwt json_string = handler(body);
+                    Dream.json(json_string);
+                  },
+                ),
+                ...actionRoutes^,
+              ];
+          };
+
+          let get_action_routes = () => actionRoutes^;
+        };

--- a/packages/server-reason-react-ppx/cram/ppx.sh
+++ b/packages/server-reason-react-ppx/cram/ppx.sh
@@ -9,7 +9,7 @@ function usage() {
   echo "       $(basename "$0") --output ml -js [file.re]"
 }
 
-js_flag=""
+melange_flag=""
 output_format=""
 input_file=""
 
@@ -20,8 +20,8 @@ while [[ $# -gt 0 ]]; do
       output_format="$2"
       shift 2
       ;;
-    -js)
-      js_flag="-js"
+     -melange)
+      melange_flag="-melange"
       shift
       ;;
     *)
@@ -38,7 +38,7 @@ if [ -z "$output_format" ] || [ -z "$input_file" ]; then
 fi
 
 refmt --parse re --print ml "$input_file" > output.ml
-./../standalone.exe --impl output.ml $js_flag -o temp.ml
+./../standalone.exe --impl output.ml $melange_flag -o temp.ml
 
 if [ "$output_format" == "ml" ]; then
   ocamlformat --enable-outside-detected-project --impl temp.ml -o temp.ml

--- a/packages/server-reason-react-ppx/cram/server-actions.t/input.re
+++ b/packages/server-reason-react-ppx/cram/server-actions.t/input.re
@@ -1,0 +1,42 @@
+// Simple action
+[@react.server.action]
+let some_action = (~a: string, ~b: int): Js.Promise.t(string) => {
+  Promise.resolve(a ++ string_of_int(b));
+};
+
+// Simple action with default value
+[@react.server.action]
+let some_action_with_default = (~a: string, ~b: int=10): Js.Promise.t(string) => {
+  Promise.resolve(a ++ string_of_int(b));
+};
+
+// Simple action with renamed argument
+[@react.server.action]
+let some_action = (~a: string, ~b as c: int): Js.Promise.t(string) => {
+  Promise.resolve(a ++ string_of_int(c));
+};
+
+// Nested module
+module Nested = {
+  [@react.server.action]
+  let some_action = (~a: string, ~b: int): Js.Promise.t(string) => {
+    Promise.resolve(a ++ string_of_int(b));
+  };
+};
+
+// With wrong return type
+[@react.server.action]
+let some_action = (~a: string, ~b: int): string => {
+  Promise.resolve(a ++ string_of_int(b));
+};
+
+// With wrong argument
+[@react.server.action]
+let some_action = (a: string, ~b: int): Js.Promise.t(string) => {
+  Promise.resolve(a ++ string_of_int(b));
+};
+
+[@react.server.action]
+let some_action = (~a, ~b: int): Js.Promise.t(string) => {
+  Promise.resolve(a ++ string_of_int(b));
+};

--- a/packages/server-reason-react-ppx/cram/server-actions.t/run.t
+++ b/packages/server-reason-react-ppx/cram/server-actions.t/run.t
@@ -1,0 +1,274 @@
+  $ ../ppx.sh --output re -melange input.re
+  let some_action = (~a: string, ~b: int) => {
+    let location = Webapi.Dom.window |> Webapi.Dom.Window.location;
+    let encodeArgs =
+      "{"
+      ++ String.concat(
+           ",",
+           List.map(
+             ((key, value)) => key ++ ":" ++ value,
+             [
+               (
+                 "a",
+                 Ppx_deriving_json_runtime.to_string([%to_json: string](a)),
+               ),
+               ("b", Ppx_deriving_json_runtime.to_string([%to_json: int](b))),
+             ],
+           ),
+         )
+      ++ "}";
+    let body = Fetch.BodyInit.make(encodeArgs);
+    let basePath =
+      switch (SRRServer.baseRoute) {
+      | Some(baseRoute) => baseRoute
+      | None => ""
+      };
+    Fetch.fetchWithInit(
+      Webapi.Dom.Location.origin(location) ++ basePath ++ "623496469",
+      Fetch.RequestInit.make(~method_=Post, ~credentials=Include, ~body, ()),
+    )
+    |> Js.Promise.then_(result =>
+         try(Fetch.Response.json(result)) {
+         | exn => Js.Promise.reject(exn)
+         }
+       )
+    |> Js.Promise.then_(json => Js.Promise.resolve([%of_json: string](json)));
+  };
+  let some_action_with_default = (~a: string, ~b: int=?) => {
+    let location = Webapi.Dom.window |> Webapi.Dom.Window.location;
+    let encodeArgs =
+      "{"
+      ++ String.concat(
+           ",",
+           List.map(
+             ((key, value)) => key ++ ":" ++ value,
+             [
+               (
+                 "a",
+                 Ppx_deriving_json_runtime.to_string([%to_json: string](a)),
+               ),
+               ("b", Ppx_deriving_json_runtime.to_string([%to_json: int](b))),
+             ],
+           ),
+         )
+      ++ "}";
+    let body = Fetch.BodyInit.make(encodeArgs);
+    let basePath =
+      switch (SRRServer.baseRoute) {
+      | Some(baseRoute) => baseRoute
+      | None => ""
+      };
+    Fetch.fetchWithInit(
+      Webapi.Dom.Location.origin(location) ++ basePath ++ "756355748",
+      Fetch.RequestInit.make(~method_=Post, ~credentials=Include, ~body, ()),
+    )
+    |> Js.Promise.then_(result =>
+         try(Fetch.Response.json(result)) {
+         | exn => Js.Promise.reject(exn)
+         }
+       )
+    |> Js.Promise.then_(json => Js.Promise.resolve([%of_json: string](json)));
+  };
+  let some_action = (~a: string, ~b as c: int) => {
+    let location = Webapi.Dom.window |> Webapi.Dom.Window.location;
+    let encodeArgs =
+      "{"
+      ++ String.concat(
+           ",",
+           List.map(
+             ((key, value)) => key ++ ":" ++ value,
+             [
+               (
+                 "a",
+                 Ppx_deriving_json_runtime.to_string([%to_json: string](a)),
+               ),
+               ("c", Ppx_deriving_json_runtime.to_string([%to_json: int](c))),
+             ],
+           ),
+         )
+      ++ "}";
+    let body = Fetch.BodyInit.make(encodeArgs);
+    let basePath =
+      switch (SRRServer.baseRoute) {
+      | Some(baseRoute) => baseRoute
+      | None => ""
+      };
+    Fetch.fetchWithInit(
+      Webapi.Dom.Location.origin(location) ++ basePath ++ "675402916",
+      Fetch.RequestInit.make(~method_=Post, ~credentials=Include, ~body, ()),
+    )
+    |> Js.Promise.then_(result =>
+         try(Fetch.Response.json(result)) {
+         | exn => Js.Promise.reject(exn)
+         }
+       )
+    |> Js.Promise.then_(json => Js.Promise.resolve([%of_json: string](json)));
+  };
+  module Nested = {
+    let some_action = (~a: string, ~b: int) => {
+      let location = Webapi.Dom.window |> Webapi.Dom.Window.location;
+      let encodeArgs =
+        "{"
+        ++ String.concat(
+             ",",
+             List.map(
+               ((key, value)) => key ++ ":" ++ value,
+               [
+                 (
+                   "a",
+                   Ppx_deriving_json_runtime.to_string([%to_json: string](a)),
+                 ),
+                 (
+                   "b",
+                   Ppx_deriving_json_runtime.to_string([%to_json: int](b)),
+                 ),
+               ],
+             ),
+           )
+        ++ "}";
+      let body = Fetch.BodyInit.make(encodeArgs);
+      let basePath =
+        switch (SRRServer.baseRoute) {
+        | Some(baseRoute) => baseRoute
+        | None => ""
+        };
+      Fetch.fetchWithInit(
+        Webapi.Dom.Location.origin(location) ++ basePath ++ "1009279222",
+        Fetch.RequestInit.make(~method_=Post, ~credentials=Include, ~body, ()),
+      )
+      |> Js.Promise.then_(result =>
+           try(Fetch.Response.json(result)) {
+           | exn => Js.Promise.reject(exn)
+           }
+         )
+      |> Js.Promise.then_(json => Js.Promise.resolve([%of_json: string](json)));
+    };
+  };
+  let some_action = [%ocaml.error
+    "server_action: expected a function that returns a Js.Promise.t"
+  ];
+  let some_action = [%ocaml.error
+    "server-reason-react: action args need to be labelled arguments"
+  ];
+  let some_action = [%ocaml.error
+    "server-reason-react: action args need to be type annotated labelled arguments"
+  ];
+ 
+
+  $ ../ppx.sh --output re input.re
+  [@react.server.action]
+  let some_action = (~a: string, ~b: int): Js.Promise.t(string) =>
+    Promise.resolve(a ++ string_of_int(b));
+  SRRServer.register_action(
+    ~route={
+      let basePath =
+        switch (SRRServer.baseRoute) {
+        | Some(baseRoute) => baseRoute
+        | None => ""
+        };
+      basePath ++ "623496469";
+    },
+    ~handler=body => {
+      let args = Yojson.Basic.from_string(body);
+      let%lwt result =
+        some_action(
+          ~a=[%of_json: string](Yojson.Basic.Util.member("a", args)),
+          ~b=[%of_json: int](Yojson.Basic.Util.member("b", args)),
+        );
+      Js.Promise.resolve(
+        Ppx_deriving_json_runtime.to_string([%to_json: string](result)),
+      );
+    },
+  );
+  [@react.server.action]
+  let some_action_with_default = (~a: string, ~b: int=10): Js.Promise.t(string) =>
+    Promise.resolve(a ++ string_of_int(b));
+  SRRServer.register_action(
+    ~route={
+      let basePath =
+        switch (SRRServer.baseRoute) {
+        | Some(baseRoute) => baseRoute
+        | None => ""
+        };
+      basePath ++ "756355748";
+    },
+    ~handler=body => {
+      let args = Yojson.Basic.from_string(body);
+      let%lwt result =
+        some_action_with_default(
+          ~a=[%of_json: string](Yojson.Basic.Util.member("a", args)),
+          ~b=[%of_json: option(int)](Yojson.Basic.Util.member("b", args)),
+        );
+      Js.Promise.resolve(
+        Ppx_deriving_json_runtime.to_string([%to_json: string](result)),
+      );
+    },
+  );
+  [@react.server.action]
+  let some_action = (~a: string, ~b as c: int): Js.Promise.t(string) =>
+    Promise.resolve(a ++ string_of_int(c));
+  SRRServer.register_action(
+    ~route={
+      let basePath =
+        switch (SRRServer.baseRoute) {
+        | Some(baseRoute) => baseRoute
+        | None => ""
+        };
+      basePath ++ "675402916";
+    },
+    ~handler=body => {
+      let args = Yojson.Basic.from_string(body);
+      let%lwt result =
+        some_action(
+          ~a=[%of_json: string](Yojson.Basic.Util.member("a", args)),
+          ~b=[%of_json: int](Yojson.Basic.Util.member("c", args)),
+        );
+      Js.Promise.resolve(
+        Ppx_deriving_json_runtime.to_string([%to_json: string](result)),
+      );
+    },
+  );
+  module Nested = {
+    [@react.server.action]
+    let some_action = (~a: string, ~b: int): Js.Promise.t(string) =>
+      Promise.resolve(a ++ string_of_int(b));
+    SRRServer.register_action(
+      ~route={
+        let basePath =
+          switch (SRRServer.baseRoute) {
+          | Some(baseRoute) => baseRoute
+          | None => ""
+          };
+        basePath ++ "1009279222";
+      },
+      ~handler=body => {
+        let args = Yojson.Basic.from_string(body);
+        let%lwt result =
+          some_action(
+            ~a=[%of_json: string](Yojson.Basic.Util.member("a", args)),
+            ~b=[%of_json: int](Yojson.Basic.Util.member("b", args)),
+          );
+        Js.Promise.resolve(
+          Ppx_deriving_json_runtime.to_string([%to_json: string](result)),
+        );
+      },
+    );
+  };
+  [@react.server.action]
+  let some_action = (~a: string, ~b: int): string =>
+    Promise.resolve(a ++ string_of_int(b));
+  [%ocaml.error
+    "server_action: expected a function that returns a Js.Promise.t"
+  ];
+  [@react.server.action]
+  let some_action = (a: string, ~b: int): Js.Promise.t(string) =>
+    Promise.resolve(a ++ string_of_int(b));
+  [%ocaml.error
+    "server-reason-react: action args need to be labelled arguments"
+  ];
+  [@react.server.action]
+  let some_action = (~a, ~b: int): Js.Promise.t(string) =>
+    Promise.resolve(a ++ string_of_int(b));
+  [%ocaml.error
+    "server-reason-react: action args need to be type annotated labelled arguments"
+  ];


### PR DESCRIPTION
## Description

This PR is the first step of creating the server actions feature for SRR.
In this part, we focus on server actions imported inside `react.client.components`.
Also is focused on JSON response content to later support server actions for FormData and other forms of response data.

It was chosen to use attribute instead of extension because we need to add extra content in this `structure_item,` and extension isn't the feature for it.

## How

The ppx is used on `structure_item` functions, so a function like this:

```reason
[@react.server.action]
let some_action = (~a: string, ~b: int): Js.Promise.t(string) => {
  Promise.resolve(a ++ string_of_int(b));
};
```

Will result in:

```reason
// Client
let some_action = (~a: string, ~b: int) => {
  let location = Webapi.Dom.window |> Webapi.Dom.Window.location;
  let encodeArgs =
    "{"
    ++ String.concat(
          ",",
          List.map(
            ((key, value)) => key ++ ":" ++ value,
            [
              (
                "a",
                Ppx_deriving_json_runtime.to_string([%to_json: string](a)),
              ),
              ("b", Ppx_deriving_json_runtime.to_string([%to_json: int](b))),
            ],
          ),
        )
    ++ "}";
  let body = Fetch.BodyInit.make(encodeArgs);
  let basePath =
    switch (SRRServer.baseRoute) {
    | Some(baseRoute) => baseRoute
    | None => ""
    };
  Fetch.fetchWithInit(
    Webapi.Dom.Location.origin(location) ++ basePath ++ "623496469",
    Fetch.RequestInit.make(~method_=Post, ~credentials=Include, ~body, ()),
  )
  |> Js.Promise.then_(result =>
        try(Fetch.Response.json(result)) {
        | exn => Js.Promise.reject(exn)
        }
      )
  |> Js.Promise.then_(json => Js.Promise.resolve([%of_json: string](json)));
};

// Server
[@react.server.action]
let some_action = (~a: string, ~b: int): Js.Promise.t(string) =>
  Promise.resolve(a ++ string_of_int(b));

SRRServer.register_action(
  ~route={
    let basePath =
      switch (SRRServer.baseRoute) {
      | Some(baseRoute) => baseRoute
      | None => ""
      };
    basePath ++ "623496469";
  },
  ~handler=body => {
    let args = Yojson.Basic.from_string(body);
    let%lwt result =
      some_action(
        ~a=[%of_json: string](Yojson.Basic.Util.member("a", args)),
        ~b=[%of_json: int](Yojson.Basic.Util.member("b", args)),
      );
    Js.Promise.resolve(
      Ppx_deriving_json_runtime.to_string([%to_json: string](result)),
    );
  },
);
```
As we can see, we don't opine on any server tool, but the ppx requires the creation of an adapter called SRRServer to connect your server tool to the actions handler, for example:
```reason
// Defines a custom base route for the actions
// Isn't required but allows the user to define a specific path
let baseRoute = Some("/api/actions/");

// Defines the functions to adapt the server actions to the server
[@platform native]
include {
          let actionRoutes = ref([]);

          let register_action = (~handler, ~route) => {
            actionRoutes :=
              [
                Dream.post(
                  route,
                  req => {
                    let%lwt body = Dream.body(req);
                    let%lwt json_string = handler(body);
                    Dream.json(json_string);
                  },
                ),
                ...actionRoutes^,
              ];
          };

          let get_action_routes = () => actionRoutes^;
        };
```

Don't know if it's the best option.
@davesnx about this adapter, any idea?
