### PR TITLE
Improve old client_props

### DIFF
--- a/packages/react/src/React.ml
+++ b/packages/react/src/React.ml
@@ -390,9 +390,11 @@ and client_props = (string * client_prop) list
 
 and client_prop =
   (* TODO: Do we need to add more types here? *)
+  | PropList : client_prop list -> client_prop
+  | Assoc : (string * client_prop) list -> client_prop
   | Json : Yojson.Basic.t -> client_prop
   | Element : element -> client_prop
-  | Promise : 'a Js.Promise.t * ('a -> Yojson.Basic.t) -> client_prop
+  | Promise : 'a Js.Promise.t * ('a -> client_prop) -> client_prop
 
 exception Invalid_children of string
 

--- a/packages/react/src/React.mli
+++ b/packages/react/src/React.mli
@@ -572,9 +572,11 @@ type element =
 and client_props = (string * client_prop) list
 
 and client_prop =
+  | PropList : client_prop list -> client_prop
+  | Assoc : (string * client_prop) list -> client_prop
   | Json : Yojson.Basic.t -> client_prop
   | Element : element -> client_prop
-  | Promise : 'a Js.Promise.t * ('a -> Yojson.Basic.t) -> client_prop
+  | Promise : 'a Js.Promise.t * ('a -> client_prop) -> client_prop
 
 exception Invalid_children of string
 

--- a/packages/reactDom/test/test_RSC_html.ml
+++ b/packages/reactDom/test/test_RSC_html.ml
@@ -251,7 +251,9 @@ let client_with_promise_props () =
             React.Client_component
               {
                 props =
-                  [ ("promise", React.Promise (delayed_value ~ms:200 "||| Resolved |||", fun res -> `String res)) ];
+                  [
+                    ("promise", React.Promise (delayed_value ~ms:200 "||| Resolved |||", fun res -> Json (`String res)));
+                  ];
                 client = React.string "Client with Props";
                 import_module = "./client-with-props.js";
                 import_name = "ClientWithProps";

--- a/packages/reactDom/test/test_RSC_model.ml
+++ b/packages/reactDom/test/test_RSC_model.ml
@@ -310,6 +310,46 @@ let client_with_json_props () =
       "0:\"$1\"\n";
     ]
 
+let client_with_complex_props () =
+  let app () =
+    React.Upper_case_component
+      (fun () ->
+        React.list
+          [
+            React.createElement "div" [] [ React.string "Server Content" ];
+            React.Client_component
+              {
+                props =
+                  [
+                    ("simple_prop", React.Json (`String "Simple string"));
+                    ( "promise_with_element",
+                      React.Promise
+                        ( delayed_value ~ms:200 "||| Element in a promise |||",
+                          fun res -> React.Element (React.createElement "div" [] [ React.string res ]) ) );
+                    ( "list_with_element",
+                      React.PropList
+                        [
+                          React.Element (React.createElement "div" [] [ React.string "||| Element 1 in a list |||" ]);
+                          React.Element (React.createElement "div" [] [ React.string "||| Element 2 in a list |||" ]);
+                        ] );
+                  ];
+                client = React.string "Client with Complex Props";
+                import_module = "./client-with-complex-props.js";
+                import_name = "ClientWithComplexProps";
+              };
+          ])
+  in
+  let%lwt stream = ReactServerDOM.render_model (app ()) in
+  assert_stream stream
+    [
+      "2:I[\"./client-with-complex-props.js\",[],\"ClientWithComplexProps\"]\n";
+      "1:[[\"$\",\"div\",null,{\"children\":\"Server Content\"}],[\"$\",\"$2\",null,{\"simple_prop\":\"Simple \
+       string\",\"promise_with_element\":\"$@3\",\"list_with_element\":[[\"$\",\"div\",null,{\"children\":\"||| \
+       Element 1 in a list |||\"}],[\"$\",\"div\",null,{\"children\":\"||| Element 2 in a list |||\"}]]}]]\n";
+      "0:\"$1\"\n";
+      "3:[\"$\",\"div\",null,{\"children\":\"||| Element in a promise |||\"}]\n";
+    ]
+
 let client_with_element_props () =
   let app () =
     React.Upper_case_component
@@ -344,7 +384,10 @@ let client_with_promise_props () =
             React.Client_component
               {
                 props =
-                  [ ("promise", React.Promise (delayed_value ~ms:200 "||| Resolved |||", fun res -> `String res)) ];
+                  [
+                    ( "promise",
+                      React.Promise (delayed_value ~ms:200 "||| Resolved |||", fun res -> React.Json (`String res)) );
+                  ];
                 client = React.string "Client with Props";
                 import_module = "./client-with-props.js";
                 import_name = "ClientWithProps";
@@ -455,6 +498,7 @@ let tests =
     test "async_component_without_suspense_immediate" async_component_without_suspense_immediate;
     test "mixed_server_and_client" mixed_server_and_client;
     test "client_with_json_props" client_with_json_props;
+    test "client_with_complex_props" client_with_complex_props;
     test "client_without_props" client_without_props;
     test "client_with_element_props" client_with_element_props;
     test "client_with_promise_props" client_with_promise_props;

--- a/packages/server-reason-react-ppx/cram/server-client-props.t/run.t
+++ b/packages/server-reason-react-ppx/cram/server-client-props.t/run.t
@@ -25,7 +25,10 @@
           ("lili", React.Json([%to_json: bool](lili))),
           ("lulu", React.Json([%to_json: float](lulu))),
           ("tuple2", React.Json([%to_json: (int, int)](tuple2))),
-          ("tuple3", React.Json([%to_json: (int, string, float)](tuple3))),
+          (
+            "tuple3",
+            React.Json([%to_json: (int, string, float)](tuple3)),
+          ),
         ],
         client: React.null,
       });
@@ -100,12 +103,18 @@
         import_name: "",
         props: [
           ("lident", React.Json([%to_json: lola](lident))),
-          ("ldotlident", React.Json([%to_json: Module.lola](ldotlident))),
+          (
+            "ldotlident",
+            React.Json([%to_json: Module.lola](ldotlident)),
+          ),
           (
             "ldotdotlident",
             React.Json([%to_json: Module.Inner.lola](ldotdotlident)),
           ),
-          ("lapply", React.Json([%to_json: Label.t(int, string)](lapply))),
+          (
+            "lapply",
+            React.Json([%to_json: Label.t(int, string)](lapply)),
+          ),
         ],
         client: React.null,
       });


### PR DESCRIPTION
## Description

The idea of this PR is to improve the old client_props and start the movement to align the behavior of SRR RSC to what React and Next do.

## Why

The react expect that response of the RSC, which evolves actions response and props response to the client, to be composable.
```reason
let props = {
    bar: {
     element: <div/>
  },
  foo: "Hey",
  baz: [<div/>, "Yah!"]
}
```

But our type nowadays is:
```ocaml
and client_prop =
  (* TODO: Do we need to add more types here? *)
  | Json : Yojson.Basic.t -> client_prop
  | Element : element -> client_prop
  | Promise : 'a Js.Promise.t * ('a -> Yojson.Basic.t) -> client_prop
```

As we can see, `Json` does not support any other `client_prop` inside it, similar to `Promise` that does not support it. They always handle a `Yojson.Basic.t`.

So we cannot have: React.Promise(promise, (response) => React.Element(response)).
How would we have such response:
```reason
// Server content that needs to be serialized
let props = {
    bar: {
     element: <div> {React.String("I'm a nested element :3")} </div>
  },
  foo: [<div> {React.String("Hey")} </div>, "Yah!"],
  baz: <div> {React.String("Who is Lola?")} </div>
}

//Let's see it as client prop
{
  "bar":  React.???(["element", React.Element(<div> {React.String("I'm a nested element :3")} </div> )])
  "foo":  React.???([React.Element(<div> {React.String("Hey")} </div>, React.Json(`String("Yah!")))])
  "baz": React.Promise(React.Element(<div> {React.String("Who is Lola?")} </div>)) // This is not valid nowaday
)
```

We need to support those React.??? and we need to make Promise to accept `client_prop` instead only Yojson type.
My propose is to provide a more complete `client_prop`:
```ocaml
and client_prop =
  | List : client_prop list -> rsc_value
  | Assoc : (string * client_prop) list -> rsc_value
  | Json : Yojson.Basic.t -> client_prop
  | Element : element -> client_prop
  | Promise : 'a Js.Promise.t * ('a -> client_prop) -> client_prop
```

Then we can handle all those types recursively, and the final return must always be either a `Yojson.Basic.t` or a `React.element`.

```reason
{
  "bar":  React.Assoc(["element", React.Element(<div> {React.String("I'm a nested element :3")} </div> )])
  "foo":  React.List([React.Element(<div> {React.String("Hey")} </div>, React.Json(`String("Yah!")))])
  "baz": React.Promise(React.Element(<div> {React.String("Who is Lola?")} </div>))
)
```

As this PR looks to adapt it for both props response and server actions, I also think that client_props is not a valid name anymore, but `rsc_value`. But as it can cause some confusion, I'm moving it to the server-actions PR.

### The code contains some `question` comments that are also already pointed into my notion of the subsequent improvements.