### PR TITLE
Add test to extract-client-component

### DIFF
--- a/packages/extract-client-components/test/ClientComponent.js
+++ b/packages/extract-client-components/test/ClientComponent.js
@@ -1,0 +1,6 @@
+// extract-client demo/universal/native/lib/Button.re
+function make_client() {}
+
+export {
+    make_client
+}

--- a/packages/extract-client-components/test/ClientComponentWithModule.js
+++ b/packages/extract-client-components/test/ClientComponentWithModule.js
@@ -1,0 +1,11 @@
+// extract-client demo/universal/native/lib/Button.re WithModule
+function make_client() {}
+
+const WithModule = {
+    make_client
+}
+
+export {
+    WithModule
+}
+

--- a/packages/extract-client-components/test/dune
+++ b/packages/extract-client-components/test/dune
@@ -1,0 +1,7 @@
+(cram
+ (package server-reason-react)
+ (deps
+  (package server-reason-react)
+  ClientComponent.js
+  ClientComponentWithModule.js
+  %{bin:server_reason_react.extract_client_components}))

--- a/packages/extract-client-components/test/run.t
+++ b/packages/extract-client-components/test/run.t
@@ -1,0 +1,13 @@
+  $ server_reason_react.extract_client_components ./ClientComponent.js
+  import React from "react";
+  window.__client_manifest_map = window.__client_manifest_map || {};
+  window.__client_manifest_map["demo/universal/native/lib/Button.re"] = React.lazy(() => import("$TESTCASE_ROOT/./ClientComponent.js").then(module => {
+    return { default: module.make_client }
+  }).catch(err => { console.error(err); return { default: null }; }))
+
+  $ server_reason_react.extract_client_components ./ClientComponentWithModule.js
+  import React from "react";
+  window.__client_manifest_map = window.__client_manifest_map || {};
+  window.__client_manifest_map["demo/universal/native/lib/Button.re"] = React.lazy(() => import("$TESTCASE_ROOT/./ClientComponentWithModule.js").then(module => {
+    return { default: module.WithModule.make_client }
+  }).catch(err => { console.error(err); return { default: null }; }))


### PR DESCRIPTION
# Descritption

There were no tests on `extract-client-component`; this PR adds one. The idea is to bring the test near the library and make it easy to run.

The tests work with `cram` as we want to ensure the command's output.