### PR TITLE
Add FormData with args to ReactServerDOM

### DIFF
--- a/demo/server/DreamRSC.re
+++ b/demo/server/DreamRSC.re
@@ -12,7 +12,7 @@ let handleFormRequest = (actionId, formData) => {
     formDataJs;
   };
 
-  let formData = ReactServerDOM.decodeFormDataReply(formData);
+  let (args, formData) = ReactServerDOM.decodeFormDataReply(formData);
 
   let actionId =
     switch (actionId) {
@@ -25,7 +25,7 @@ let handleFormRequest = (actionId, formData) => {
     | Some(FormData(handler)) => handler
     | _ => assert(false)
     };
-  handler(formData);
+  handler(args, formData);
 };
 
 let handleRequestBody = (request, actionId) => {

--- a/demo/server/pages/SinglePageRSC.re
+++ b/demo/server/pages/SinglePageRSC.re
@@ -173,16 +173,23 @@ module Page = {
         </Section>
         <Hr />
         <Section
-          title="Server action with error"
-          description="Server action with error">
+          title="Server function with error"
+          description="Server function with error">
           <ServerActionWithError />
         </Section>
         <Hr />
         <Section
-          title="Server action with FormData"
-          description="Server action with FormData">
+          title="Server function with FormData"
+          description="Server function with FormData">
           <ServerActionWithFormData />
         </Section>
+        <Hr />
+        <Section
+          title="Server function with FormData with extra arg"
+          description="It shows that it's possible to pass extra arguments to the server function on forms">
+          <ServerActionWithFormDataWithArg />
+        </Section>
+        <Hr />
       </Stack>,
     );
   };

--- a/demo/universal/native/shared/ServerActionWithFormDataWithArg.re
+++ b/demo/universal/native/shared/ServerActionWithFormDataWithArg.re
@@ -1,0 +1,27 @@
+[@react.client.component]
+let make = () => {
+  <form
+    action={
+      switch%platform () {
+      | Server => ""
+      | Client =>
+        Obj.magic(
+          ServerFunctions.formDataWithArg.call(
+            Js.Date.now() |> string_of_float,
+          ),
+        )
+      }
+    }
+    className={Cx.make([Theme.text(Theme.Color.Gray4)])}>
+    <input
+      name="country"
+      className="w-full mb-2 font-sans border border-gray-300 py-2 px-4 rounded-md bg-white text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200"
+      placeholder="Name"
+    />
+    <button
+      className="font-mono border-2 py-1 px-2 rounded-lg bg-yellow-950 border-yellow-700 text-yellow-200 hover:bg-yellow-800"
+      type_="submit">
+      {React.string("Send Form Data")}
+    </button>
+  </form>;
+};

--- a/packages/reactDom/src/ReactServerDOM.mli
+++ b/packages/reactDom/src/ReactServerDOM.mli
@@ -14,11 +14,11 @@ val create_action_response :
   ?env:[ `Dev | `Prod ] -> ?debug:bool -> ?subscribe:(string -> unit Lwt.t) -> React.client_value Lwt.t -> unit Lwt.t
 
 type server_function =
-  | FormData of (Js.FormData.t -> React.client_value Lwt.t)
+  | FormData of (Yojson.Basic.t array -> Js.FormData.t -> React.client_value Lwt.t)
   | Body of (Yojson.Basic.t array -> React.client_value Lwt.t)
 
 val decodeReply : string -> Yojson.Basic.t array
-val decodeFormDataReply : Js.FormData.t -> Js.FormData.t
+val decodeFormDataReply : Js.FormData.t -> Yojson.Basic.t array * Js.FormData.t
 
 module type FunctionReferences = sig
   type t

--- a/packages/reactDom/test/test.ml
+++ b/packages/reactDom/test/test.ml
@@ -10,4 +10,5 @@ let () =
             Test_RSC_model.tests;
             Test_RSC_html.tests;
             Test_html_shell_generation.tests;
+            Test_RSC_decoders.tests;
           ]))

--- a/packages/reactDom/test/test_RSC_decoders.ml
+++ b/packages/reactDom/test/test_RSC_decoders.ml
@@ -1,0 +1,36 @@
+let assert_string left right = Alcotest.check Alcotest.string "should be equal" right left
+
+let decodeReply () =
+  let response = ReactServerDOM.decodeReply "[\"Lola\", 20]" in
+  match response with
+  | [| `String hello; `Int age |] ->
+      assert_string hello "Lola";
+      Alcotest.check Alcotest.int "should be equal" age 20
+  | _ -> Alcotest.fail "Something went wrong on the decodeReply"
+
+let decodeFormDataReply () =
+  let formData = Js.FormData.make () in
+  Js.FormData.append formData "1_name" (`String "Lola");
+  Js.FormData.append formData "1_age" (`String "20");
+  Js.FormData.append formData "0" (`String "[\"$K1\"]");
+  let _, formData = ReactServerDOM.decodeFormDataReply formData in
+  match (Js.FormData.get formData "name", Js.FormData.get formData "age") with
+  | `String name, `String age ->
+      assert_string name "Lola";
+      assert_string age "20"
+
+let decodeFormDataReplyWithArg () =
+  let formData = Js.FormData.make () in
+  Js.FormData.append formData "1_name" (`String "Lola");
+  Js.FormData.append formData "1_age" (`String "20");
+  Js.FormData.append formData "0" (`String "[\"Hello\", \"$K1\"]");
+  let args, formData = ReactServerDOM.decodeFormDataReply formData in
+  match (args, Js.FormData.get formData "name", Js.FormData.get formData "age") with
+  | [| `String greet |], `String name, `String age ->
+      assert_string greet "Hello";
+      assert_string name "Lola";
+      assert_string age "20"
+  | _ -> Alcotest.fail "Something went wrong on the decodeFormDataReplyWithArg"
+
+let test title fn = (Printf.sprintf "Decoders / %s" title, [ Alcotest_lwt.test_case_sync "" `Quick fn ])
+let tests = [ test "decodeReply" decodeReply; test "decodeFormDataReply" decodeFormDataReply ]


### PR DESCRIPTION
## Description

Add FormData with args to ReactServerDOM and Demo.

## Details

This PR adds to the formData decoder a way to handle extra arguments:

```reason
[@platform native]
let formDataWithArgHandler = (timestamp: string, ~formData: Js.FormData.t) => {
  let country =
    switch (formData->Js.FormData.get("country")) {
    | `String(country) => country
    };

  let response =
    Printf.sprintf(
      "Form data received: %s, timestamp: %s",
      country,
      timestamp,
    );

  Lwt.return(React.Json(`String(response)));
};

// ...
ServerFunctions.formDataWithArg.call(Js.Date.now() |> string_of_float);
```