### PR TITLE
Add server function to action

### DIFF
--- a/demo/server/pages/SinglePageRSC.re
+++ b/demo/server/pages/SinglePageRSC.re
@@ -63,7 +63,6 @@ module Page = {
       Lwt.bind(Lwt_unix.sleep(2.0), _ =>
         Lwt.return("Solusionao in 2 seconds!")
       );
-
     let promiseIn4 =
       Lwt.bind(Lwt_unix.sleep(4.0), _ =>
         Lwt.return("Solusionao in 4 seconds!")
@@ -173,15 +172,27 @@ module Page = {
         </Section>
         <Hr />
         <Section
-          title="Server action with error"
-          description="Server action with error">
+          title="Server function with error"
+          description="Server function with error">
           <ServerActionWithError />
         </Section>
         <Hr />
         <Section
-          title="Server action with FormData"
-          description="Server action with FormData">
+          title="Server function with FormData"
+          description="Server function with FormData">
           <ServerActionWithFormData />
+        </Section>
+        <Hr />
+        <Section
+          title="Server function with FormData on action attribute on Server Component"
+          description="In this case, react will use the server function from the window.__server_functions_manifest_map">
+          <ServerActionWithFormDataServer />
+        </Section>
+        <Hr />
+        <Section
+          title="Server function with FormData on formAction attribute on Server Component"
+          description="In this case, react will use the server function from the window.__server_functions_manifest_map">
+          <ServerActionWithFormDataFormAction />
         </Section>
       </Stack>,
     );

--- a/demo/universal/native/shared/ServerActionWithFormDataFormAction.re
+++ b/demo/universal/native/shared/ServerActionWithFormDataFormAction.re
@@ -1,19 +1,18 @@
-[@react.client.component]
+[@react.component]
 let make = () => {
-  <form
-    action={
-      switch%platform () {
-      | Server => `String("")
-      | Client => Obj.magic(ServerFunctions.formData.call)
-      }
-    }
-    className={Cx.make([Theme.text(Theme.Color.Gray4)])}>
+  <form className={Cx.make([Theme.text(Theme.Color.Gray4)])}>
     <input
       name="name"
       className="w-full mb-2 font-sans border border-gray-300 py-2 px-4 rounded-md bg-white text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200"
       placeholder="Name"
     />
     <button
+      formAction={
+        switch%platform () {
+        | Server => `Function(ServerFunctions.formData)
+        | Client => ""
+        }
+      }
       className="font-mono border-2 py-1 px-2 rounded-lg bg-yellow-950 border-yellow-700 text-yellow-200 hover:bg-yellow-800"
       type_="submit">
       {React.string("Send Form Data")}

--- a/demo/universal/native/shared/ServerActionWithFormDataServer.re
+++ b/demo/universal/native/shared/ServerActionWithFormDataServer.re
@@ -1,10 +1,11 @@
-[@react.client.component]
+[@react.component]
 let make = () => {
   <form
     action={
       switch%platform () {
-      | Server => `String("")
-      | Client => Obj.magic(ServerFunctions.formData.call)
+      | Server => `Function(ServerFunctions.formData)
+      // doesn't matter the client value, it will never reach the browser
+      | Client => ""
       }
     }
     className={Cx.make([Theme.text(Theme.Color.Gray4)])}>

--- a/packages/react/src/React.ml
+++ b/packages/react/src/React.ml
@@ -336,6 +336,7 @@ module JSX = struct
     | Inline of string
 
   type prop =
+    | Action : (string * string * _ Runtime.server_function) -> prop
     | Bool of (string * string * bool)
     | String of (string * string * string)
     | Style of (string * string * string) list
@@ -429,6 +430,7 @@ let attributes_to_map attributes =
       | DangerouslyInnerHtml _ -> acc
       | Ref _ -> acc
       | Event _ -> acc
+      | Action _ -> acc
       | Style _ -> acc)
     StringMap.empty attributes
 

--- a/packages/react/src/React.mli
+++ b/packages/react/src/React.mli
@@ -517,6 +517,7 @@ module JSX : sig
 
   (** JSX.prop is the representation of HTML/SVG attributes and DOM events *)
   type prop =
+    | Action : (string * string * _ Runtime.server_function) -> prop
     | Bool of (string * string * bool)
     | String of (string * string * string)
     | Style of (string * string * string) list

--- a/packages/reactDom/src/ReactDOM.ml
+++ b/packages/reactDom/src/ReactDOM.ml
@@ -17,6 +17,7 @@ let attribute_to_html attr =
   | Bool (_name, _, false) -> Html.omitted ()
   (* true attributes render solely the attribute name *)
   | Bool (name, _, true) -> Html.present name
+  | Action (_, _, _) -> Html.omitted ()
   | Style styles -> Html.attribute "style" (ReactDOMStyle.to_string styles)
   | String (name, _, _value) when is_react_custom_attribute name -> Html.omitted ()
   | String (name, _, value) -> Html.attribute name value

--- a/packages/reactDom/src/ReactServerDOM.ml
+++ b/packages/reactDom/src/ReactServerDOM.ml
@@ -104,6 +104,7 @@ module Model = struct
     | React.JSX.DangerouslyInnerHtml html -> Some ("dangerouslySetInnerHTML", `Assoc [ ("__html", `String html) ])
     | React.JSX.Ref _ -> None
     | React.JSX.Event _ -> None
+    | React.JSX.Action _ -> None
 
   let props_to_json props = List.filter_map prop_to_json props
 
@@ -195,6 +196,17 @@ module Model = struct
       (* TODO: Do we need to html encode the model or only the html? *)
       | Text t -> `String t
       | Lower_case_element { key; tag; attributes; children } ->
+          let attributes =
+            List.map
+              (fun prop ->
+                match prop with
+                | React.JSX.Action (_, key, f) ->
+                    let id = use_chunk_id context in
+                    context.push id (Chunk_value (`Assoc [ ("id", `String f.id); ("bound", `Null) ]));
+                    React.JSX.String (key, key, action_value id)
+                | _ -> prop)
+              attributes
+          in
           let props = props_to_json attributes in
           node ~key ~tag ~props (List.map (turn_element_into_payload ~context) children)
       | Fragment children ->
@@ -430,7 +442,23 @@ let rec client_to_html ~fiber (element : React.element) =
   | Array childrens ->
       let%lwt html = childrens |> Array.to_list |> Lwt_list.map_p (client_to_html ~fiber) in
       Lwt.return (Html.list html)
-  | Lower_case_element { key; tag; attributes; children } -> render_lower_case ~fiber ~key ~tag ~attributes ~children
+  | Lower_case_element { key; tag; attributes; children } ->
+      let context = Fiber.get_context fiber in
+      let attributes =
+        List.map
+          (fun prop ->
+            match prop with
+            | React.JSX.Action (_, key, f) ->
+                let index = Fiber.use_index fiber in
+                let html =
+                  chunk_script (Model.model_to_chunk index (`Assoc [ ("id", `String f.id); ("bound", `Null) ]))
+                in
+                context.push html;
+                React.JSX.String (key, key, Model.action_value index)
+            | _ -> prop)
+          attributes
+      in
+      render_lower_case ~fiber ~key ~tag ~attributes ~children
   | Upper_case_component (_name, component) ->
       let rec wait_for_suspense_to_resolve () =
         match component () with
@@ -466,11 +494,9 @@ let rec client_to_html ~fiber (element : React.element) =
   | Consumer children -> client_to_html ~fiber children
 
 and render_lower_case ~fiber ~key:_ ~tag ~attributes ~children =
-  if Html.is_self_closing_tag tag then
-    let html_props = ReactDOM.attributes_to_html attributes in
-    Lwt.return (Html.node tag html_props [])
+  let html_props = ReactDOM.attributes_to_html attributes in
+  if Html.is_self_closing_tag tag then Lwt.return (Html.node tag html_props [])
   else
-    let html_props = ReactDOM.attributes_to_html attributes in
     let children = ReactDOM.moveDangerouslyInnerHtmlAsChildren attributes children in
     let%lwt html = children |> Lwt_list.map_p (client_to_html ~fiber) in
     Lwt.return (Html.node tag html_props html)
@@ -516,14 +542,27 @@ let rec to_html ~(fiber : Fiber.t) (element : React.element) : (Html.element * j
         to_html ~fiber (React.List children)
       else
         let children = ReactDOM.moveDangerouslyInnerHtmlAsChildren attributes children in
+        let context = Fiber.get_context fiber in
+        let html_props = ReactDOM.attributes_to_html attributes in
+        let json_attributes =
+          List.map
+            (fun prop ->
+              match prop with
+              | React.JSX.Action (_, key, f) ->
+                  let index = Fiber.use_index fiber in
+                  let html =
+                    chunk_script (Model.model_to_chunk index (`Assoc [ ("id", `String f.id); ("bound", `Null) ]))
+                  in
+                  context.push html;
+                  React.JSX.String (key, key, Model.action_value index)
+              | _ -> prop)
+            attributes
+        in
+        let json_props = Model.props_to_json json_attributes in
         if Html.is_self_closing_tag tag then
-          let html_props = ReactDOM.attributes_to_html attributes in
-          let json_props = Model.props_to_json attributes in
           let empty_children = (* there's no children for self closing tags *) [] in
           Lwt.return (Html.node tag html_props empty_children, Model.node ~tag ~key ~props:json_props empty_children)
         else
-          let html_props = ReactDOM.attributes_to_html attributes in
-          let json_props = Model.props_to_json attributes in
           let%lwt html, model = elements_to_html ~fiber children in
           Lwt.return (Html.node tag html_props [ html ], Model.node ~tag ~key ~props:json_props [ model ])
   | Async_component (_, component) ->

--- a/packages/reactDom/test/dune
+++ b/packages/reactDom/test/dune
@@ -8,6 +8,7 @@
   lwt
   server-reason-react.react
   server-reason-react.reactDom
+  server-reason-react.runtime
   server-reason-react.html
   server-reason-react.js
   alcotest

--- a/packages/reactDom/test/test_RSC_html.ml
+++ b/packages/reactDom/test/test_RSC_html.ml
@@ -433,6 +433,31 @@ let await_tick ?(raise = false) num =
         let%lwt () = sleep ~ms:(Random.int 10) in
         if raise then Lwt.fail (Failure "lol") else Lwt.return (React.string num) )
 
+let server_function_as_action () =
+  let app () =
+    React.Upper_case_component
+      ( "app",
+        fun () ->
+          React.createElement "form"
+            [
+              React.JSX.Action
+                ( "action",
+                  "action",
+                  { Runtime.id = "1234-4321"; call = (fun () -> Lwt.return (React.string "Server Content")) } );
+            ]
+            [ React.string "Server Content" ] )
+  in
+  let main = React.Upper_case_component ("app", app) in
+  assert_html main ~disable_backtrace:true
+    ~shell:
+      "<form>Server Content</form><script data-payload='0:[\"$\",\"form\",null,{\"children\":[\"Server \
+       Content\"],\"action\":\"$F1\"},null,[],{}]\n\
+       '>window.srr_stream.push()</script>"
+    [
+      "<script data-payload='1:{\"id\":\"1234-4321\",\"bound\":null}\n'>window.srr_stream.push()</script>";
+      "<script>window.srr_stream.close()</script>";
+    ]
+
 let suspense_in_a_list_with_error () =
   let fallback = React.string "Loading..." in
   let app () =
@@ -481,4 +506,5 @@ let tests =
     test "error_without_suspense" error_without_suspense;
     test "error_in_toplevel_in_async" error_in_toplevel_in_async;
     test "suspense_in_a_list_with_error" suspense_in_a_list_with_error;
+    test "server_function_as_action" server_function_as_action;
   ]

--- a/packages/server-reason-react-ppx/DomProps.ml
+++ b/packages/server-reason-react-ppx/DomProps.ml
@@ -5,6 +5,7 @@
 let ( & ) = List.append
 
 type attributeType =
+  | Action
   | String
   | Int
   | Bool
@@ -605,7 +606,7 @@ let buttonHTMLAttributes =
     Attribute { name = "autocomplete"; jsxName = "autoComplete"; reasonJsxName = "autoComplete"; type_ = String };
     Attribute { name = "disabled"; jsxName = "disabled"; reasonJsxName = "disabled"; type_ = Bool };
     Attribute { name = "form"; jsxName = "form"; reasonJsxName = "form"; type_ = String };
-    Attribute { name = "formaction"; jsxName = "formAction"; reasonJsxName = "formAction"; type_ = String };
+    Attribute { name = "formaction"; jsxName = "formAction"; reasonJsxName = "formAction"; type_ = Action };
     Attribute { name = "formenctype"; jsxName = "formEncType"; reasonJsxName = "formEncType"; type_ = String };
     (* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#method *)
     Attribute { name = "formmethod"; jsxName = "formMethod"; reasonJsxName = "formMethod"; type_ = String };
@@ -686,7 +687,7 @@ let formHTMLAttributes =
     Attribute { name = "name"; jsxName = "name"; reasonJsxName = "name"; type_ = String };
     Attribute { name = "rel"; jsxName = "rel"; reasonJsxName = "rel"; type_ = String };
     Attribute { name = "enctype"; jsxName = "encType"; reasonJsxName = "encType"; type_ = String };
-    Attribute { name = "action"; jsxName = "action"; reasonJsxName = "action"; type_ = String };
+    Attribute { name = "action"; jsxName = "action"; reasonJsxName = "action"; type_ = Action };
     Attribute { name = "method"; jsxName = "method"; reasonJsxName = "method_"; type_ = String };
     Attribute { name = "novalidate"; jsxName = "noValidate"; reasonJsxName = "noValidate"; type_ = Bool };
     Attribute { name = "target"; jsxName = "target"; reasonJsxName = "target"; type_ = String };

--- a/packages/server-reason-react-ppx/DomProps.mli
+++ b/packages/server-reason-react-ppx/DomProps.mli
@@ -1,4 +1,4 @@
-type attributeType = String | Int | Bool | BooleanishString | Style | Ref | InnerHtml
+type attributeType = Action | String | Int | Bool | BooleanishString | Style | Ref | InnerHtml
 
 type eventType =
   | Clipboard

--- a/packages/server-reason-react-ppx/cram/component-definition.t/input.re
+++ b/packages/server-reason-react-ppx/cram/component-definition.t/input.re
@@ -72,6 +72,51 @@ module Form_with_method = {
   [@react.component]
   let make = (~children) => <form method_="GET"> children </form>;
 };
+
+module Form_with_method = {
+  [@react.component]
+  let make = (~children) => <form action={`String("")}> children </form>;
+};
+
+module Form_with_action_function = {
+  [@react.component]
+  let make = (~children) =>
+    <form
+      action={
+               `Function({
+                 id: "123",
+                 call: () => Js.Promise.resolve("Hello"),
+               })
+             }>
+      children
+    </form>;
+};
+
+module Form_with_action_string = {
+  [@react.component]
+  let make = (~children) => <form action={`String("")}> children </form>;
+};
+
+module Button_with_formAction_string = {
+  [@react.component]
+  let make = (~children) =>
+    <button formAction={`String("")}> children </button>;
+};
+
+module Button_with_formAction_function = {
+  [@react.component]
+  let make = (~children) =>
+    <button
+      formAction={
+                   `Function({
+                     id: "123",
+                     call: () => Js.Promise.resolve("Hello"),
+                   })
+                 }>
+      children
+    </button>;
+};
+
 let a = <Uppercase> <div /> </Uppercase>;
 
 module Async_component = {

--- a/packages/server-reason-react-ppx/cram/component-definition.t/run.t
+++ b/packages/server-reason-react-ppx/cram/component-definition.t/run.t
@@ -123,6 +123,137 @@ We need to output ML syntax here, otherwise refmt could not parse it.
               [ children ] )
   end
   
+  module Form_with_method = struct
+    let make ?key:(_ : string option) ~children () =
+      React.Upper_case_component
+        ( __FUNCTION__,
+          fun () ->
+            React.createElementWithKey ~key:None "form"
+              (Stdlib.List.filter_map Fun.id
+                 [
+                   (match
+                      (`String ""
+                        : [ `String of string
+                          | `Function of 'a Runtime.server_function ])
+                    with
+                   | `String s ->
+                       Some (React.JSX.String ("action", "action", (s : string)))
+                   | `Function f ->
+                       Some
+                         (React.JSX.Action
+                            ("action", "action", (f : 'a Runtime.server_function))));
+                 ])
+              [ children ] )
+  end
+  
+  module Form_with_action_function = struct
+    let make ?key:(_ : string option) ~children () =
+      React.Upper_case_component
+        ( __FUNCTION__,
+          fun () ->
+            React.createElementWithKey ~key:None "form"
+              (Stdlib.List.filter_map Fun.id
+                 [
+                   (match
+                      (`Function
+                         {
+                           id = "123";
+                           call = (fun () -> Js.Promise.resolve "Hello");
+                         }
+                        : [ `String of string
+                          | `Function of 'a Runtime.server_function ])
+                    with
+                   | `String s ->
+                       Some (React.JSX.String ("action", "action", (s : string)))
+                   | `Function f ->
+                       Some
+                         (React.JSX.Action
+                            ("action", "action", (f : 'a Runtime.server_function))));
+                 ])
+              [ children ] )
+  end
+  
+  module Form_with_action_string = struct
+    let make ?key:(_ : string option) ~children () =
+      React.Upper_case_component
+        ( __FUNCTION__,
+          fun () ->
+            React.createElementWithKey ~key:None "form"
+              (Stdlib.List.filter_map Fun.id
+                 [
+                   (match
+                      (`String ""
+                        : [ `String of string
+                          | `Function of 'a Runtime.server_function ])
+                    with
+                   | `String s ->
+                       Some (React.JSX.String ("action", "action", (s : string)))
+                   | `Function f ->
+                       Some
+                         (React.JSX.Action
+                            ("action", "action", (f : 'a Runtime.server_function))));
+                 ])
+              [ children ] )
+  end
+  
+  module Button_with_formAction_string = struct
+    let make ?key:(_ : string option) ~children () =
+      React.Upper_case_component
+        ( __FUNCTION__,
+          fun () ->
+            React.createElementWithKey ~key:None "button"
+              (Stdlib.List.filter_map Fun.id
+                 [
+                   (match
+                      (`String ""
+                        : [ `String of string
+                          | `Function of 'a Runtime.server_function ])
+                    with
+                   | `String s ->
+                       Some
+                         (React.JSX.String
+                            ("formaction", "formAction", (s : string)))
+                   | `Function f ->
+                       Some
+                         (React.JSX.Action
+                            ( "formaction",
+                              "formAction",
+                              (f : 'a Runtime.server_function) )));
+                 ])
+              [ children ] )
+  end
+  
+  module Button_with_formAction_function = struct
+    let make ?key:(_ : string option) ~children () =
+      React.Upper_case_component
+        ( __FUNCTION__,
+          fun () ->
+            React.createElementWithKey ~key:None "button"
+              (Stdlib.List.filter_map Fun.id
+                 [
+                   (match
+                      (`Function
+                         {
+                           id = "123";
+                           call = (fun () -> Js.Promise.resolve "Hello");
+                         }
+                        : [ `String of string
+                          | `Function of 'a Runtime.server_function ])
+                    with
+                   | `String s ->
+                       Some
+                         (React.JSX.String
+                            ("formaction", "formAction", (s : string)))
+                   | `Function f ->
+                       Some
+                         (React.JSX.Action
+                            ( "formaction",
+                              "formAction",
+                              (f : 'a Runtime.server_function) )));
+                 ])
+              [ children ] )
+  end
+  
   let a =
     Uppercase.make ~children:(React.createElementWithKey ~key:None "div" [] []) ()
   

--- a/packages/server-reason-react-ppx/dune
+++ b/packages/server-reason-react-ppx/dune
@@ -12,6 +12,7 @@
   compiler-libs.common
   ppxlib
   ppxlib.astlib
-  server-reason-react.react)
+  server-reason-react.react
+  server-reason-react.runtime)
  (preprocess
   (pps ppxlib.metaquot)))

--- a/packages/server-reason-react-ppx/server_reason_react_ppx.ml
+++ b/packages/server-reason-react-ppx/server_reason_react_ppx.ml
@@ -108,6 +108,18 @@ let make_prop ~is_optional ~prop attribute_value =
   let loc = attribute_value.pexp_loc in
   let open DomProps in
   match (prop, is_optional) with
+  | Attribute { type_ = DomProps.Action; name; jsxName }, false ->
+      [%expr
+        match ([%e attribute_value] : [ `String of string | `Function of 'a Runtime.server_function ]) with
+        | `String s -> Some (React.JSX.String ([%e estring ~loc name], [%e estring ~loc jsxName], (s : string)))
+        | `Function f ->
+            Some
+              (React.JSX.Action ([%e estring ~loc name], [%e estring ~loc jsxName], (f : 'a Runtime.server_function)))]
+  | Attribute { type_ = DomProps.Action; name; jsxName }, true ->
+      [%expr
+        match ([%e attribute_value] : [ `String of string | `Function of 'a Runtime.server_function ] option) with
+        | None -> None
+        | Some v -> Some (React.JSX.Action ([%e estring ~loc name], [%e estring ~loc jsxName], v))]
   | Attribute { type_ = DomProps.String; name; jsxName }, false ->
       [%expr
         Some (React.JSX.String ([%e estring ~loc name], [%e estring ~loc jsxName], ([%e attribute_value] : string)))]


### PR DESCRIPTION
## Description

 This PR makes the `action` attribute work with `string` and `function`.

## Details

The action attribute now works with`` `String of string | `Function of 'a Runtime.server_function ``.

> [!IMPORTANT]  
> This makes action incompatible with reason-react. It requires the usage of switch%platform always.