### PR TITLE
feat: add React.raw for raw html

### DIFF
--- a/packages/react/src/React.ml
+++ b/packages/react/src/React.ml
@@ -382,6 +382,7 @@ type element =
   | List of element list
   | Array of element array
   | Text of string
+  | DangerouslyInnerHtml of string
   | Fragment of element
   | Empty
   | Provider of element
@@ -470,6 +471,7 @@ let cloneElement element new_attributes =
   | Lower_case_element { key; tag; attributes; children } ->
       Lower_case_element { key; tag; attributes = clone_attributes attributes new_attributes; children }
   | Upper_case_component _ -> raise (Invalid_argument "In server-reason-react, a component can't be cloned")
+  | DangerouslyInnerHtml _ -> raise (Invalid_argument "can't clone innerHtml")
   | Fragment _ -> raise (Invalid_argument "can't clone a fragment")
   | Text _ -> raise (Invalid_argument "can't clone a text element")
   | Empty -> raise (Invalid_argument "can't clone a null element")

--- a/packages/react/src/React.mli
+++ b/packages/react/src/React.mli
@@ -565,6 +565,7 @@ type element =
   | List of element list
   | Array of element array
   | Text of string
+  | DangerouslyInnerHtml of string
   | Fragment of element
   | Empty
   | Provider of element

--- a/packages/react/test/test_react.ml
+++ b/packages/react/test/test_react.ml
@@ -94,6 +94,10 @@ let invalid_dangerouslySetInnerHtml () =
     (React.Invalid_children {|"meta" is a self-closing tag and must not have "dangerouslySetInnerHTML".\n|})
     raises
 
+let raw_element () =
+  let app = React.Upper_case_component ("app", fun () -> React.DangerouslyInnerHtml "<div>Hello</div>") in
+  assert_string (ReactDOM.renderToStaticMarkup app) "<div>Hello</div>"
+
 let tests =
   ( "React",
     [
@@ -105,4 +109,5 @@ let tests =
       test "useRef" use_ref_works;
       test "invalid_children" invalid_children;
       test "invalid_dangerouslySetInnerHtml" invalid_dangerouslySetInnerHtml;
+      test "raw_element" raw_element;
     ] )

--- a/packages/reactDom/src/ReactDOM.ml
+++ b/packages/reactDom/src/ReactDOM.ml
@@ -42,6 +42,7 @@ let render ~mode element =
   let rec render_element element =
     match (element : React.element) with
     | Empty -> Html.null
+    | DangerouslyInnerHtml html -> Html.raw html
     | Client_component { import_module; _ } ->
         raise
           (Invalid_argument
@@ -136,6 +137,7 @@ let rec render_to_stream ~stream_context element =
   let rec render_element element =
     match (element : React.element) with
     | Empty -> Lwt.return Html.null
+    | DangerouslyInnerHtml html -> Lwt.return (Html.raw html)
     | Client_component { import_module; _ } ->
         raise
           (Invalid_argument
@@ -246,6 +248,7 @@ and render_with_resolved ~stream_context element =
         | Lwt.Sleep ->
             let%lwt resolved = promise in
             render_element resolved)
+    | DangerouslyInnerHtml html -> Lwt.return (Html.raw html)
     | Suspense _ -> render_to_stream ~stream_context element
   and render_lower_case ~key:_ tag attributes children =
     let inner_html = getDangerouslyInnerHtml attributes in

--- a/packages/reactDom/src/ReactServerDOM.ml
+++ b/packages/reactDom/src/ReactServerDOM.ml
@@ -193,6 +193,7 @@ module Model = struct
     let rec turn_element_into_payload ~context element =
       match (element : React.element) with
       | Empty -> `Null
+      | DangerouslyInnerHtml html -> `String html
       (* TODO: Do we need to html encode the model or only the html? *)
       | Text t -> `String t
       | Lower_case_element { key; tag; attributes; children } ->
@@ -428,6 +429,7 @@ let html_suspense_placeholder ~fallback id =
 let rec client_to_html ~fiber (element : React.element) =
   match element with
   | Empty -> Lwt.return Html.null
+  | DangerouslyInnerHtml html -> Lwt.return (Html.raw html)
   | Text text -> Lwt.return (Html.string text)
   | Fragment children -> client_to_html ~fiber children
   | List childrens ->
@@ -501,6 +503,7 @@ let is_a_head_child_tag tag = tag = "title" || tag = "meta" || tag = "link" || t
 let rec to_html ~(fiber : Fiber.t) (element : React.element) : (Html.element * json) Lwt.t =
   match element with
   | Empty -> Lwt.return (Html.null, `Null)
+  | DangerouslyInnerHtml html -> Lwt.return (Html.raw html, `String html)
   | Text s -> Lwt.return (Html.string s, `String s)
   | Fragment children -> to_html ~fiber children
   | List list -> elements_to_html ~fiber list

--- a/packages/reactDom/test/test_RSC_html.ml
+++ b/packages/reactDom/test/test_RSC_html.ml
@@ -521,6 +521,12 @@ let suspense_in_a_list_with_error () =
       "<script>window.srr_stream.close()</script>";
     ]
 
+let raw_element () =
+  let app () = React.DangerouslyInnerHtml "<div>Hello</div>" in
+  assert_html (app ())
+    ~shell:"<div>Hello</div><script data-payload='0:\"<div>Hello</div>\"\n'>window.srr_stream.push()</script>"
+    [ "<script>window.srr_stream.close()</script>" ]
+
 let tests =
   [
     test "self_closing_with_dangerously" self_closing_with_dangerously;
@@ -542,5 +548,6 @@ let tests =
     test "error_in_toplevel_in_async" error_in_toplevel_in_async;
     test "suspense_in_a_list_with_error" suspense_in_a_list_with_error;
     test "server_function_as_action" server_function_as_action;
+    test "raw_element" raw_element;
     (* test "debug_adds_debug_info" debug_adds_debug_info; *)
   ]

--- a/packages/reactDom/test/test_RSC_model.ml
+++ b/packages/reactDom/test/test_RSC_model.ml
@@ -731,6 +731,13 @@ let env_development_adds_debug_info () =
     ];
   Lwt.return ()
 
+let raw_element () =
+  let app = React.DangerouslyInnerHtml "<div>Hello</div>" in
+  let output, subscribe = capture_stream () in
+  let%lwt () = ReactServerDOM.render_model ~subscribe app in
+  assert_list_of_strings !output [ "0:\"<div>Hello</div>\"\n" ];
+  Lwt.return ()
+
 (* let env_development_adds_debug_info_2 () =
   let app () =
     React.Fragment
@@ -793,6 +800,7 @@ let tests =
     test "error_in_toplevel_in_async" error_in_toplevel_in_async;
     test "suspense_in_a_list_with_error" suspense_in_a_list_with_error;
     test "suspense_with_error_under_lowercase" suspense_with_error_under_lowercase;
+    test "raw_element" raw_element;
     (* TODO: https://github.com/ml-in-barcelona/server-reason-react/issues/251 test "client_with_promise_failed_props" client_with_promise_failed_props; *)
     (* test "env_development_adds_debug_info_2" env_development_adds_debug_info_2; *)
   ]


### PR DESCRIPTION
## Description

After removing the React.InnerHtml, we couldn't have raw HTML being rendered on the server