### PR TITLE
Simplify universal path on PPX

### DIFF
--- a/demo/universal/js/dune
+++ b/demo/universal/js/dune
@@ -24,6 +24,6 @@
    reason-react-ppx
    melange-json.ppx)))
 
-(copy_files
+(copy_files#
  (mode fallback)
  (files "../native/shared/*.re"))


### PR DESCRIPTION
## Description

This PR tries to rethink the way we create the `extract-client-component` flag.

## Before

On the `extract-client-component` flag, we used to change the `/js` to `/native/shared`.
But it assumes that native is going to be the source of the shared components, which could not.
So this is a fragile solution.

## After

My proposal in this PR is to use `copy_files#` instead of `copy_files` as it keeps the location of the file copied. ([REF](https://dune.readthedocs.io/en/latest/reference/actions/copy%23.html)) 

### Before

On `demo/universal` we had the `/native` folder as source of truth of shared components, and that's how it's copied on `/js/dune`:
```
(copy_files
 (mode fallback)
 (files "../native/shared/*.re"))
```

For all the copies of the native, we would turn it into a `demo/universal/js` file, then on the build, we would have the `demo/universal/js/Button.re` value for the `rewrite_structure_item_for_js`, and that requires a replace to make `native` and `js` aligned:  
```
      let fileName = Str.replace_first (Str.regexp {|/js/|}) "/native/shared/" fileName in
```

### After

On demo/universal/js we have:

```
(copy_files#
 (mode fallback)
 (files "../native/shared/*.re"))
```

In this case, we have the `demo/universal/native/shared/Button.re` value for the `rewrite_structure_item_for_js`, even running by Melange, so the replace isn't necessary anymore, and it also does not depend on any folder name and how the user declares the source of shared modules.
