### PR TITLE
feat: add to ppx the root arg

### DIFF
--- a/packages/server-reason-react-ppx/cram/client-component-on-the-server.t/run.t
+++ b/packages/server-reason-react-ppx/cram/client-component-on-the-server.t/run.t
@@ -111,7 +111,7 @@
         (),
       ) =>
     React.Client_component({
-      import_module: __FILE__,
+      import_module: "input.re",
       import_name: "",
       props: [
         ("initial", React.Json(int_to_json(initial))),

--- a/packages/server-reason-react-ppx/cram/replace-melange-folder-hack.t/js/input.re
+++ b/packages/server-reason-react-ppx/cram/replace-melange-folder-hack.t/js/input.re
@@ -1,0 +1,4 @@
+open Melange_json.Primitives;
+
+[@react.client.component]
+let make = () => React.null;

--- a/packages/server-reason-react-ppx/cram/replace-melange-folder-hack.t/run.t
+++ b/packages/server-reason-react-ppx/cram/replace-melange-folder-hack.t/run.t
@@ -1,0 +1,48 @@
+  $ cat > dune-project << EOF
+  > (lang dune 3.10)
+  > (using melange 0.1)
+  > EOF
+
+  $ cat > dune << EOF
+  > (include_subdirs unqualified)
+  > (melange.emit
+  >  (target js)
+  >  (libraries reason-react melange-json)
+  >  (preprocess (pps melange.ppx melange-json.ppx server-reason-react.ppx --replace-melange-folder-hack=js/ -melange)))
+  > EOF
+
+  $ dune describe pp js/input.re
+  [@ocaml.ppx.context
+    {
+      tool_name: "ppx_driver",
+      include_dirs: [],
+      hidden_include_dirs: [],
+      load_path: [@ppxlib.migration.load_path ([], [])] [],
+      open_modules: [],
+      for_package: None,
+      debug: false,
+      use_threads: false,
+      use_vmthreads: false,
+      recursive_types: false,
+      principal: false,
+      transparent_modules: false,
+      unboxed_types: false,
+      unsafe_string: false,
+      cookies: [],
+    }
+  ];
+  open Melange_json.Primitives;
+  
+  include {
+            {
+              module J = {
+                [@ocaml.warning "-unboxable-type-in-prim-decl"]
+                external unsafe_expr: _ => _ = "#raw_stmt";
+              };
+              J.unsafe_expr("// extract-client input.re");
+            };
+  
+            [@react.component]
+            let make = () => React.null;
+            let make_client = props => make(Js.Obj.empty());
+          };

--- a/packages/server-reason-react-ppx/cram/replace-melange-folder-hack.t/run.t
+++ b/packages/server-reason-react-ppx/cram/replace-melange-folder-hack.t/run.t
@@ -8,7 +8,7 @@
   > (melange.emit
   >  (target js)
   >  (libraries reason-react melange-json)
-  >  (preprocess (pps melange.ppx melange-json.ppx server-reason-react.ppx --replace-melange-folder-hack=js/ -melange)))
+  >  (preprocess (pps melange.ppx melange-json.ppx server-reason-react.ppx --shared-folder-prefix=js/ -melange)))
   > EOF
 
   $ dune describe pp js/input.re

--- a/packages/server-reason-react-ppx/cram/replace-native-folder-hack.t/native/input.re
+++ b/packages/server-reason-react-ppx/cram/replace-native-folder-hack.t/native/input.re
@@ -1,0 +1,2 @@
+[@react.client.component]
+let make = () => React.null;

--- a/packages/server-reason-react-ppx/cram/replace-native-folder-hack.t/run.t
+++ b/packages/server-reason-react-ppx/cram/replace-native-folder-hack.t/run.t
@@ -1,0 +1,39 @@
+  $ cat > dune-project << EOF
+  > (lang dune 3.10)
+  > EOF
+
+  $ cat > dune << EOF
+  > (include_subdirs unqualified)
+  > (executable
+  >  (name input)
+  >  (libraries server-reason-react.react server-reason-react.runtime server-reason-react.reactDom melange-json)
+  >  (preprocess (pps server-reason-react.ppx --replace-native-folder-hack=native/ server-reason-react.melange_ppx melange-json-native.ppx)))
+  > EOF
+
+  $ dune describe pp native/input.re
+  [@ocaml.ppx.context
+    {
+      tool_name: "ppx_driver",
+      include_dirs: [],
+      hidden_include_dirs: [],
+      load_path: [@ppxlib.migration.load_path ([], [])] [],
+      open_modules: [],
+      for_package: None,
+      debug: false,
+      use_threads: false,
+      use_vmthreads: false,
+      recursive_types: false,
+      principal: false,
+      transparent_modules: false,
+      unboxed_types: false,
+      unsafe_string: false,
+      cookies: [],
+    }
+  ];
+  let make = (~key as _: option(string)=?, ()) =>
+    React.Client_component({
+      import_module: "input.re",
+      import_name: "",
+      props: [],
+      client: React.null,
+    });

--- a/packages/server-reason-react-ppx/cram/replace-native-folder-hack.t/run.t
+++ b/packages/server-reason-react-ppx/cram/replace-native-folder-hack.t/run.t
@@ -7,7 +7,7 @@
   > (executable
   >  (name input)
   >  (libraries server-reason-react.react server-reason-react.runtime server-reason-react.reactDom melange-json)
-  >  (preprocess (pps server-reason-react.ppx --replace-native-folder-hack=native/ server-reason-react.melange_ppx melange-json-native.ppx)))
+  >  (preprocess (pps server-reason-react.ppx --shared-folder-prefix=native/ server-reason-react.melange_ppx melange-json-native.ppx)))
   > EOF
 
   $ dune describe pp native/input.re

--- a/packages/server-reason-react-ppx/cram/server-client-props.t/run.t
+++ b/packages/server-reason-react-ppx/cram/server-client-props.t/run.t
@@ -16,7 +16,7 @@
         ) =>
       React.Client_component({
         import_module:
-          Printf.sprintf("%s#%s", __FILE__, "Prop_with_many_annotation"),
+          Printf.sprintf("%s#%s", "output.ml", "Prop_with_many_annotation"),
         import_name: "",
         props: [
           ("prop", React.Json([%to_json: int](prop))),
@@ -35,7 +35,7 @@
     let make = (~key as _: option(string)=?, ~prop_without_annotation, ()) =>
       React.Client_component({
         import_module:
-          Printf.sprintf("%s#%s", __FILE__, "Prop_without_annotation"),
+          Printf.sprintf("%s#%s", "output.ml", "Prop_without_annotation"),
         import_name: "",
         props: [
           [%ocaml.error
@@ -50,7 +50,11 @@
         (~key as _: option(string)=?, ~underscore: _, ~alpha_types: 'a, ()) =>
       React.Client_component({
         import_module:
-          Printf.sprintf("%s#%s", __FILE__, "Prop_with_unsupported_annotation"),
+          Printf.sprintf(
+            "%s#%s",
+            "output.ml",
+            "Prop_with_unsupported_annotation",
+          ),
         import_name: "",
         props: [
           ("underscore", React.Json([%to_json: _](underscore))),
@@ -73,7 +77,7 @@
         import_module:
           Printf.sprintf(
             "%s#%s",
-            __FILE__,
+            "output.ml",
             "Prop_with_annotation_that_need_to_be_type_alias",
           ),
         import_name: "",
@@ -105,7 +109,7 @@
         ) =>
       React.Client_component({
         import_module:
-          Printf.sprintf("%s#%s", __FILE__, "Prop_with_unknown_annotation"),
+          Printf.sprintf("%s#%s", "output.ml", "Prop_with_unknown_annotation"),
         import_name: "",
         props: [
           ("lident", React.Json([%to_json: lola](lident))),

--- a/packages/server-reason-react-ppx/server_reason_react_ppx.ml
+++ b/packages/server-reason-react-ppx/server_reason_react_ppx.ml
@@ -6,8 +6,7 @@ type target = Native | Js
 
 (* Since ppxlib doesn't provide a way to get the submodules, we need to keep track of them manually *)
 let mode = ref Native
-let replace_melange_folder_hack = ref "/js"
-let replace_native_folder_hack = ref "/native/shared"
+let shared_folder_prefix = ref "/native/shared"
 let repo_url = "https://github.com/ml-in-barcelona/server-reason-react"
 let issues_url = Printf.sprintf "%s/issues" repo_url
 
@@ -733,7 +732,7 @@ module ServerFunction = struct
 
   let generate_id ~loc name =
     (* We need to add a nasty hack here, since have different files for native and melange.Assume that the file structure is native/lib and js, and replace the name directly. This is supposed to be temporal, until dune implements https://github.com/ocaml/dune/issues/10630 *)
-    let file_path = loc.loc_start.pos_fname |> Str.replace_first (Str.regexp replace_native_folder_hack.contents) "" in
+    let file_path = loc.loc_start.pos_fname |> Str.replace_first (Str.regexp shared_folder_prefix.contents) "" in
     let hash = Printf.sprintf "%s_%s_%d" name file_path loc.loc_start.pos_lnum |> Hashtbl.hash |> string_of_int in
     hash
 
@@ -956,7 +955,7 @@ let rewrite_structure_item ~nested_module_names structure_item =
               let loc = expr.pexp_loc in
               let file =
                 expr.pexp_loc.loc_start.pos_fname
-                |> Str.replace_first (Str.regexp replace_native_folder_hack.contents) ""
+                |> Str.replace_first (Str.regexp shared_folder_prefix.contents) ""
                 |> estring ~loc
               in
               let import_module =
@@ -1010,7 +1009,7 @@ let rewrite_structure_item_for_js ~nested_module_names ctx structure_item =
       let code_path = Expansion_context.Base.code_path ctx in
       let fileName = Code_path.file_path code_path in
       (* We need to add a nasty hack here, since have different files for native and melange.Assume that the file structure is /native/shared/ and js, and replace the name directly. This is supposed to be temporal, until dune implements https://github.com/ocaml/dune/issues/10630 *)
-      let fileName = Str.replace_first (Str.regexp replace_melange_folder_hack.contents) "" fileName in
+      let fileName = Str.replace_first (Str.regexp shared_folder_prefix.contents) "" fileName in
       let comment =
         match nested_module_names with
         | [] -> estring ~loc (Printf.sprintf "// extract-client %s" fileName)
@@ -1108,9 +1107,8 @@ let traverse =
 
 let () =
   Driver.add_arg "-melange" (Unit (fun () -> mode := Js)) ~doc:"preprocess for js build";
-  Driver.add_arg "--replace-melange-folder-hack"
-    (String (fun str -> replace_melange_folder_hack := str))
-    ~doc:"root path";
-  Driver.add_arg "--replace-native-folder-hack" (String (fun str -> replace_native_folder_hack := str)) ~doc:"root path";
+  Driver.add_arg "--shared-folder-prefix"
+    (String (fun str -> shared_folder_prefix := str))
+    ~doc:"prefix of shared files in melange, used to generate ids for the shared files";
   Ppxlib.Driver.V2.register_transformation "server-reason-react.ppx" ~preprocess_impl:traverse#structure
     ~preprocess_intf:traverse#signature

--- a/packages/server-reason-react-ppx/server_reason_react_ppx.ml
+++ b/packages/server-reason-react-ppx/server_reason_react_ppx.ml
@@ -6,7 +6,7 @@ type target = Native | Js
 
 (* Since ppxlib doesn't provide a way to get the submodules, we need to keep track of them manually *)
 let mode = ref Native
-let replace_melange_folder_hack = ref "/native/shared"
+let replace_melange_folder_hack = ref "/js"
 let replace_native_folder_hack = ref "/native/shared"
 let repo_url = "https://github.com/ml-in-barcelona/server-reason-react"
 let issues_url = Printf.sprintf "%s/issues" repo_url


### PR DESCRIPTION
## Description
This PR tries to re-think the way we create the extract-client-component flag.

## Before

On the extract-client-component flag, we used to change the /js to /native/shared.
But it assumes that native is going to be the source of the shared components, which could not.

## After
By default, the native system replaces /native/shared with nothing, while Melange does the same for /js.
If anyone, for some reason, wants to customize it, it should be done with the --replace_melange_folder_hack and --replace_native_folder_hack args.