### PR TITLE
Fix mismatch of the model and html on render_html

### DIFF
--- a/demo/client/DummyRouterRSC.re
+++ b/demo/client/DummyRouterRSC.re
@@ -119,7 +119,7 @@ let body =
   ->Webapi.Dom.Document.asHtmlDocument
   ->Option.bind(Webapi.Dom.HtmlDocument.body);
 
-switch (body) {
+switch (document) {
 | Some(element) =>
   React.startTransition(() => {
     let _ = ReactDOM.Client.hydrateRoot(element, <App />);

--- a/demo/server/pages/DummyRouterRSC.re
+++ b/demo/server/pages/DummyRouterRSC.re
@@ -100,50 +100,72 @@ module App = {
   [@react.async.component]
   let make = (~selectedId, ~isEditing, ~searchText, ~sleep) => {
     Lwt.return(
-      <DemoLayout background=Theme.Color.Gray2 mode=FullScreen>
-        <div className="flex flex-row gap-8">
-          <section
-            className="flex-1 basis-1/4 gap-4 min-w-[400px]" key="sidebar">
-            <section
-              className="flex flex-col gap-1 z-1 max-w-[85%] pointer-events-none mb-6"
-              key="sidebar-header">
-              <Text size=Large weight=Bold> "server-reason-react notes" </Text>
-              <p>
-                <Text color=Theme.Color.Gray10> "migrated from " </Text>
-                <Link.Text
-                  size=Text.Small
-                  href="https://github.com/reactjs/server-components-demo">
-                  "reactjs/server-components-demo"
-                </Link.Text>
-                <Text color=Theme.Color.Gray10>
-                  " with (server)-reason-react and Melange"
-                </Text>
-              </p>
-            </section>
-            <section
-              className="mt-4 mb-4 flex flex-row gap-2"
-              role="menubar"
-              key="menubar">
-              <SearchField searchText selectedId isEditing />
-            </section>
-            <nav className="mt-4">
-              <div className="mb-4"> <Hr /> </div>
-              <div className="mb-4">
-                <Button noteId=None> {React.string("Create a note")} </Button>
-              </div>
-              <Hr />
-              <React.Suspense fallback={<NoteListSkeleton />}>
-                <NoteList searchText sleep />
-              </React.Suspense>
-            </nav>
-          </section>
-          <section key="note-viewer" className="flex-1 basis-3/4 max-w-[75%]">
-            <React.Suspense fallback={<NoteSkeleton isEditing />}>
-              <NoteItem selectedId isEditing sleep />
-            </React.Suspense>
-          </section>
-        </div>
-      </DemoLayout>,
+      <html>
+        <head>
+          <meta charSet="utf-8" />
+          <style
+            dangerouslySetInnerHTML={
+              "__html":
+                markdownStyles(
+                  ~background=Theme.Color.gray2,
+                  ~text=Theme.Color.gray12,
+                ),
+            }
+          />
+          <link rel="stylesheet" href="/output.css" />
+        </head>
+        <body>
+          <DemoLayout background=Theme.Color.Gray2 mode=FullScreen>
+            <div className="flex flex-row gap-8">
+              <section
+                className="flex-1 basis-1/4 gap-4 min-w-[400px]" key="sidebar">
+                <section
+                  className="flex flex-col gap-1 z-1 max-w-[85%] pointer-events-none mb-6"
+                  key="sidebar-header">
+                  <Text size=Large weight=Bold>
+                    "server-reason-react notes"
+                  </Text>
+                  <p>
+                    <Text color=Theme.Color.Gray10> "migrated from " </Text>
+                    <Link.Text
+                      size=Text.Small
+                      href="https://github.com/reactjs/server-components-demo">
+                      "reactjs/server-components-demo"
+                    </Link.Text>
+                    <Text color=Theme.Color.Gray10>
+                      " with (server)-reason-react and Melange"
+                    </Text>
+                  </p>
+                </section>
+                <section
+                  className="mt-4 mb-4 flex flex-row gap-2"
+                  role="menubar"
+                  key="menubar">
+                  <SearchField searchText selectedId isEditing />
+                </section>
+                <nav className="mt-4">
+                  <div className="mb-4"> <Hr /> </div>
+                  <div className="mb-4">
+                    <Button noteId=None>
+                      {React.string("Create a note")}
+                    </Button>
+                  </div>
+                  <Hr />
+                  <React.Suspense fallback={<NoteListSkeleton />}>
+                    <NoteList searchText sleep />
+                  </React.Suspense>
+                </nav>
+              </section>
+              <section
+                key="note-viewer" className="flex-1 basis-3/4 max-w-[75%]">
+                <React.Suspense fallback={<NoteSkeleton isEditing />}>
+                  <NoteItem selectedId isEditing sleep />
+                </React.Suspense>
+              </section>
+            </div>
+          </DemoLayout>
+        </body>
+      </html>,
     );
   };
 };
@@ -181,24 +203,6 @@ let handler = request => {
   DreamRSC.createFromRequest(
     ~disableSSR=!ssr,
     ~bootstrapModules=["/static/demo/DummyRouterRSC.re.js"],
-    ~layout=
-      children =>
-        <html lang="en">
-          <head>
-            <meta charSet="utf-8" />
-            <style
-              dangerouslySetInnerHTML={
-                "__html":
-                  markdownStyles(
-                    ~background=Theme.Color.gray2,
-                    ~text=Theme.Color.gray12,
-                  ),
-              }
-            />
-            <link rel="stylesheet" href="/output.css" />
-          </head>
-          <body> children </body>
-        </html>,
     <App selectedId isEditing searchText sleep />,
     request,
   );

--- a/packages/reactDom/src/ReactServerDOM.ml
+++ b/packages/reactDom/src/ReactServerDOM.ml
@@ -696,19 +696,19 @@ and render_lower_case_element ~fiber ~key ~tag ~attributes ~children =
         fiber.inside_head <- true;
         (* push the head element to the hoisted_head *)
         let%lwt value =
-          render_hoisted_element ~fiber ~key ~tag ~attributes ~children ~inner_html ~on_push:Fiber.push_hoisted_head
+          handle_hoistable_element ~fiber ~key ~tag ~attributes ~children ~inner_html ~on_push:Fiber.push_hoisted_head
         in
         fiber.inside_head <- false;
         Lwt.return value
     | tag when (tag = "script" && is_async attributes) || (tag = "link" && has_precedence_and_rel_stylesheet attributes)
       ->
-        render_hoisted_element ~fiber ~key ~tag ~attributes ~children ~inner_html ~on_push:Fiber.push_resource
+        handle_hoistable_element ~fiber ~key ~tag ~attributes ~children ~inner_html ~on_push:Fiber.push_resource
     | tag when tag = "title" || tag = "meta" || tag = "link" ->
-        render_hoisted_element ~fiber ~key ~tag ~attributes ~children ~inner_html
+        handle_hoistable_element ~fiber ~key ~tag ~attributes ~children ~inner_html
           ~on_push:Fiber.push_hoisted_head_childrens
     | _ -> render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html
 
-and render_hoisted_element ~fiber ~key ~tag ~attributes ~children ~inner_html ~on_push =
+and handle_hoistable_element ~fiber ~key ~tag ~attributes ~children ~inner_html ~on_push =
   let props = Model.props_to_json attributes in
 
   let create_model children =

--- a/packages/reactDom/src/ReactServerDOM.ml
+++ b/packages/reactDom/src/ReactServerDOM.ml
@@ -23,27 +23,24 @@ let create_stack_trace () =
 
 (* Resources module maintains insertion order while deduplicating based on src/href *)
 module Resources = struct
-  type item = string * Html.attribute_list * Html.element option
-  type t = item list
-
   let get_attribute ~key:key_to_get (attributes : Html.attribute_list) =
     List.find_map
       (fun attr -> match attr with `Value (key, value) when String.equal key key_to_get -> Some value | _ -> None)
       attributes
 
   let resource_key item =
-    match (item : item) with
-    | "script", attributes, _ -> get_attribute ~key:"src" attributes
-    | "link", attributes, _ -> get_attribute ~key:"href" attributes
+    match (item : Html.node) with
+    | { tag = "script"; attributes; _ } -> get_attribute ~key:"src" attributes
+    | { tag = "link"; attributes; _ } -> get_attribute ~key:"href" attributes
     | _ -> None
 
   let add resource resources =
     match resource_key resource with
-    | None -> resources @ [ resource ]
+    | None -> resources @ [ Html.Node resource ]
     | Some key ->
         (* Ensure if this resource already exists, it gets deduplicated *)
-        let exists = List.exists (fun r -> resource_key r = Some key) resources in
-        if exists then resources else resources @ [ resource ]
+        let exists = List.exists (function Html.Node node -> resource_key node = Some key | _ -> false) resources in
+        if exists then resources else resources @ [ Html.Node resource ]
 end
 
 module Fiber = struct
@@ -60,20 +57,25 @@ module Fiber = struct
     (* visited_first_lower_case stores the tag of the first lower case element visited, useful to know if the root element is an html tag *)
     mutable visited_first_lower_case : string option;
     (* hoisted_head stores the <head> element's attributes and direct children *)
-    mutable hoisted_head : (Html.attribute_list * Html.element list) option;
+    mutable hoisted_head : Html.node option;
     (* hoisted_head_childrens collects elements that should be in the document's <head> (title, meta, link, style) even if they weren't originally inside a <head> element *)
     mutable hoisted_head_childrens : Html.element list;
     (* resources collects link, script that should preload, prefetch to be in the document's <head> and deduplicates them based on "src" or "href" attributes, respectively *)
-    mutable resources : Resources.t;
+    mutable resources : Html.element list;
     (* inside_head tracks whether we're currently processing elements inside a <head> element *)
     mutable inside_head : bool;
+    (* inside_body tracks whether we're currently processing elements inside a <body> element *)
+    mutable inside_body : bool;
+    (* As we reconstruct the html tag, html_tag_attributes collects the attributes of the <html> tag *)
+    mutable html_tag_attributes : Html.attribute_list;
   }
 
-  let push_hoisted_head ~fiber html_attributes children = fiber.hoisted_head <- Some (html_attributes, children)
+  let set_html_tag_attributes ~fiber html_attributes = fiber.html_tag_attributes <- html_attributes
+  let push_hoisted_head ~fiber head = fiber.hoisted_head <- Some head
   let push_resource ~fiber resource = fiber.resources <- Resources.add resource fiber.resources
 
   let push_hoisted_head_childrens ~fiber children =
-    fiber.hoisted_head_childrens <- fiber.hoisted_head_childrens @ [ children ]
+    fiber.hoisted_head_childrens <- fiber.hoisted_head_childrens @ [ Node children ]
 
   let visited_first_lower_case ~fiber = fiber.visited_first_lower_case
   let set_visited_first_lower_case ~fiber value = fiber.visited_first_lower_case <- Some value
@@ -662,75 +664,71 @@ and render_lower_case_element ~fiber ~key ~tag ~attributes ~children =
   (* Head hoisting mechanism:
      Head elements (meta, style, title, etc) might be scattered throughout the component tree but need to be rendered in the <head> section. Also, if there's no head element, we need to create one and hoist its possible children. *)
   let inner_html = ReactDOM.getDangerouslyInnerHtml attributes in
-  let props = Model.props_to_json attributes in
-
-  let create_model children =
-    if (* disable_model *) true then
-      (* Currently we don't sent the model for those cases, since we hydrate the document.body as soon as we hydrate the entire document *)
-      `Null
-    else
-      (* In case of the model, we don't care about inner_html as a children since we need it as a prop. This is the opposite from html rendering *)
-      match (Html.is_self_closing_tag tag, inner_html) with
-      | _, Some _ | true, _ -> Model.node ~tag ~key ~props []
-      | false, None -> Model.node ~tag ~key ~props [ children ]
-  in
-
-  let create_html_node ~html_props ~children_html =
-    match inner_html with
-    | Some inner_html -> Html.node tag html_props [ Html.raw inner_html ]
-    | None -> Html.node tag html_props [ children_html ]
-  in
 
   (* only set the first element visited true, the first time *)
   (match Fiber.visited_first_lower_case ~fiber with
   | Some _ -> ()
   | None -> Fiber.set_visited_first_lower_case ~fiber tag);
 
-  match tag with
-  | "html" -> (
-      (* TODO: What the model should be?
-        let%lwt _html, model = render_element_to_html ~fiber (React.List children) in
-        let%lwt children, _children_model = elements_to_html ~fiber children in
-        let html = create_html_node ~html_props:[] ~children_html:children in
-        Lwt.return (html, model) *)
-      match Fiber.visited_first_lower_case ~fiber with
-      (* If the first visited lower case is an html element -> skip rendering the html tag itself, just process children. That's because we will reconstuct the html element at the "render_html" *)
-      | Some "html" -> render_element_to_html ~fiber (React.List children)
-      (* In case of rendering html tag as not the first visited lower case element, means that something is wrapping this html tag (like a div or other element) which is invalid HTML, but we keep rendering as a regular element, as React.js' DOM renderer does *)
-      | Some _ -> render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html
-      | None ->
-          (* the None case isn't possible, since we call set_visited_first_lower_case ~fiber tag in the beginning of the function *)
-          render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html)
-  | "head" ->
-      (* Hoist head element to be rendered at document level *)
-      let html_attributes = ReactDOM.attributes_to_html attributes in
-      (* Mark that we're inside a head element to prevent double-hoisting *)
-      fiber.inside_head <- true;
-      let%lwt html_and_model = Lwt_list.map_p (render_element_to_html ~fiber) children in
-      fiber.inside_head <- false;
-      let html, model = List.split html_and_model in
-      Fiber.push_hoisted_head ~fiber html_attributes html;
-      Lwt.return (Html.null, create_model (`List model))
-  | tag when (tag = "script" && is_async attributes) || (tag = "link" && has_precedence_and_rel_stylesheet attributes)
-    ->
-      (* Hoist resources (scripts, links) - but only if not already inside a head *)
-      if fiber.inside_head then render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html
-      else
-        let html_props = ReactDOM.attributes_to_html attributes in
-        (* TODO: What we should do with the model? *)
-        let%lwt _children_html, children_model = elements_to_html ~fiber children in
-        Fiber.push_resource ~fiber (tag, html_props, None);
-        Lwt.return (Html.null, create_model children_model)
-  | tag when tag = "title" || tag = "meta" || tag = "link" ->
-      (* Hoist title, meta, and links without rel or precedence - but only if not already inside a head *)
-      if fiber.inside_head then render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html
-      else
-        let html_props = ReactDOM.attributes_to_html attributes in
-        let%lwt children_html, children_model = elements_to_html ~fiber children in
-        let html = create_html_node ~html_props ~children_html in
-        Fiber.push_hoisted_head_childrens ~fiber html;
-        Lwt.return (Html.null, create_model children_model)
-  | _ -> render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html
+  if fiber.inside_head && not fiber.inside_body then
+    render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html
+  else
+    match tag with
+    | "html" -> (
+        match Fiber.visited_first_lower_case ~fiber with
+        (* If the first visited lower case is an html element -> skip rendering the html tag itself, just process children. That's because we will reconstuct the html element at the "render_html" *)
+        | Some "html" ->
+            Fiber.set_html_tag_attributes ~fiber (ReactDOM.attributes_to_html attributes);
+            let%lwt html, model = render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html in
+            let html_children = match html with Html.Node { children; _ } -> Html.list children | _ -> html in
+            Lwt.return (html_children, model)
+        (* In case of rendering html tag as not the first visited lower case element, means that something is wrapping this html tag (like a div or other element) which is invalid HTML, but we keep rendering as a regular element, as React.js' DOM renderer does *)
+        | Some _ -> render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html
+        | None ->
+            (* the None case isn't possible, since we call set_visited_first_lower_case ~fiber tag in the beginning of the function *)
+            render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html)
+    | "body" ->
+        fiber.inside_body <- true;
+        let%lwt value = render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html in
+        fiber.inside_body <- false;
+        Lwt.return value
+    | "head" ->
+        fiber.inside_head <- true;
+        (* push the head element to the hoisted_head *)
+        let%lwt value =
+          render_hoisted_element ~fiber ~key ~tag ~attributes ~children ~inner_html ~on_push:Fiber.push_hoisted_head
+        in
+        fiber.inside_head <- false;
+        Lwt.return value
+    | tag when (tag = "script" && is_async attributes) || (tag = "link" && has_precedence_and_rel_stylesheet attributes)
+      ->
+        render_hoisted_element ~fiber ~key ~tag ~attributes ~children ~inner_html ~on_push:Fiber.push_resource
+    | tag when tag = "title" || tag = "meta" || tag = "link" ->
+        render_hoisted_element ~fiber ~key ~tag ~attributes ~children ~inner_html
+          ~on_push:Fiber.push_hoisted_head_childrens
+    | _ -> render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html
+
+and render_hoisted_element ~fiber ~key ~tag ~attributes ~children ~inner_html ~on_push =
+  let props = Model.props_to_json attributes in
+
+  let create_model children =
+    (* In case of the model, we don't care about inner_html as a children since we need it as a prop. This is the opposite from html rendering *)
+    match (Html.is_self_closing_tag tag, inner_html) with
+    | _, Some _ | true, _ -> Model.node ~tag ~key ~props []
+    | false, None -> Model.node ~tag ~key ~props [ children ]
+  in
+
+  let create_html_node ~html_props ~children_html =
+    match inner_html with
+    | Some inner_html -> Html.{ tag; attributes = html_props; children = [ Html.raw inner_html ] }
+    | None -> Html.{ tag; attributes = html_props; children = [ children_html ] }
+  in
+
+  let html_props = ReactDOM.attributes_to_html attributes in
+  let%lwt children_html, children_model = elements_to_html ~fiber children in
+  let html = create_html_node ~html_props ~children_html in
+  on_push ~fiber html;
+  Lwt.return (Html.null, create_model children_model)
 
 and render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html =
   let context = Fiber.get_context fiber in
@@ -793,28 +791,36 @@ let render_html ?(skipRoot = false) ?(env = `Dev) ?debug:(_ = false) ?bootstrapS
     | Some scripts ->
         List.map
           (fun script ->
-            ( "link",
-              [
-                Html.attribute "rel" "modulepreload";
-                Html.attribute "fetchPriority" "low";
-                Html.attribute "href" script;
-                (* Html.attribute "as" "script"; *)
-              ],
-              None ))
+            Html.Node
+              {
+                tag = "link";
+                attributes =
+                  [
+                    Html.attribute "rel" "modulepreload";
+                    Html.attribute "fetchPriority" "low";
+                    Html.attribute "href" script;
+                    (* Html.attribute "as" "script"; *)
+                  ];
+                children = [];
+              })
           scripts
     | None -> (
         match bootstrapModules with
         | Some modules ->
             List.map
               (fun script ->
-                ( "link",
-                  [
-                    Html.attribute "rel" "modulepreload";
-                    Html.attribute "fetchPriority" "low";
-                    Html.attribute "href" script;
-                    (* Html.attribute "as" "script"; *)
-                  ],
-                  None ))
+                Html.Node
+                  {
+                    tag = "link";
+                    attributes =
+                      [
+                        Html.attribute "rel" "modulepreload";
+                        Html.attribute "fetchPriority" "low";
+                        Html.attribute "href" script;
+                        (* Html.attribute "as" "script"; *)
+                      ];
+                    children = [];
+                  })
               modules
         | None -> [])
   in
@@ -825,9 +831,11 @@ let render_html ?(skipRoot = false) ?(env = `Dev) ?debug:(_ = false) ?bootstrapS
       context;
       hoisted_head = None;
       hoisted_head_childrens = [];
+      html_tag_attributes = [];
       resources = initial_resources;
       visited_first_lower_case = None;
       inside_head = false;
+      inside_body = false;
     }
   in
   let%lwt root_html, root_model = render_element_to_html ~fiber element in
@@ -883,23 +891,15 @@ let render_html ?(skipRoot = false) ?(env = `Dev) ?debug:(_ = false) ?bootstrapS
         | true, true | false, true -> Html.list user_scripts
         | false, false -> Html.list (root_html :: user_scripts)
       in
-      let head_childrens =
-        List.map
-          (fun (tag, attributes, children) ->
-            match children with
-            | Some children -> Html.node tag attributes [ children ]
-            | None -> Html.node tag attributes [])
-          fiber.resources
-        @ fiber.hoisted_head_childrens
-      in
+      let resources = fiber.resources @ fiber.hoisted_head_childrens in
       match fiber.hoisted_head with
-      | Some (attribute_list, children) ->
+      | Some node ->
           (* If we found a <head> element, use its attributes and combine all children *)
-          let head = Html.node "head" attribute_list (head_childrens @ children) in
-          Html.node "html" [] [ head; body ]
+          let head = Html.Node { node with children = node.children @ resources } in
+          Html.node "html" fiber.html_tag_attributes [ head; body ]
       | None ->
           (* If no explicit <head> was found, create one with the hoisted children *)
-          Html.node "html" [] [ Html.node "head" [] head_childrens; body ]
+          Html.node "html" fiber.html_tag_attributes [ Html.node "head" [] resources; body ]
     else if skipRoot then Html.list user_scripts
     else Html.list (root_html :: user_scripts)
   in

--- a/packages/reactDom/test/test_RSC_html_shell.ml
+++ b/packages/reactDom/test/test_RSC_html_shell.ml
@@ -17,7 +17,7 @@ let test title fn =
           test_promise);
     ] )
 
-let html children = React.createElement "html" [] children
+let html ?(attributes = []) children = React.createElement "html" attributes children
 let head children = React.createElement "head" [] children
 let body children = React.createElement "body" [] children
 let input attributes = React.createElement "input" attributes []
@@ -65,14 +65,16 @@ srr_stream.readable_stream = new ReadableStream({ start(c) { srr_stream._c = c; 
 let just_an_html_node () =
   let app = html [] in
   assert_html app
-    ~shell:"<!DOCTYPE html><html><head></head><script data-payload='0:[]\n'>window.srr_stream.push()</script></html>"
+    ~shell:
+      "<!DOCTYPE html><html><head></head><script data-payload='0:[\"$\",\"html\",null,{\"children\":[]},null,[],{}]\n\
+       '>window.srr_stream.push()</script></html>"
 
 let doctype () =
   let app = html [ head []; body [] ] in
   assert_html app
     ~shell:
       "<!DOCTYPE html><html><head></head><body></body><script \
-       data-payload='0:[null,[\"$\",\"body\",null,{\"children\":[]},null,[],{}]]\n\
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"head\",null,{\"children\":[]},null,[],{}],[\"$\",\"body\",null,{\"children\":[]},null,[],{}]]},null,[],{}]\n\
        '>window.srr_stream.push()</script></html>"
 
 let no_head_no_body_nothing_just_an_html_node () =
@@ -84,25 +86,26 @@ let html_with_a_node () =
   let app = html [ input [] ] in
   assert_html app
     ~shell:
-      "<!DOCTYPE html><html><head></head><input /><script data-payload='0:[[\"$\",\"input\",null,{},null,[],{}]]\n\
+      "<!DOCTYPE html><html><head></head><input /><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"input\",null,{},null,[],{}]]},null,[],{}]\n\
        '>window.srr_stream.push()</script></html>"
 
 let html_with_only_a_body () =
   let app = html [ body [ div [] [ React.string "Just body content" ] ] ] in
   assert_html app
     ~shell:
-      "<!DOCTYPE html><html><head></head><body><div>Just body content</div><script \
-       data-payload='0:[[\"$\",\"body\",null,{\"children\":[[\"$\",\"div\",null,{\"children\":[\"Just body \
-       content\"]},null,[],{}]]},null,[],{}]]\n\
-       '>window.srr_stream.push()</script></body></html>"
+      "<!DOCTYPE html><html><head></head><body><div>Just body content</div></body><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"body\",null,{\"children\":[[\"$\",\"div\",null,{\"children\":[\"Just \
+       body content\"]},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
+       '>window.srr_stream.push()</script></html>"
 
 let html_with_no_srr_html_body () =
   let app = html [ body [ div [] [ React.string "Just body content" ] ] ] in
   assert_html app ~skipRoot:true
     ~shell:
       "<!DOCTYPE html><html><head></head><script \
-       data-payload='0:[[\"$\",\"body\",null,{\"children\":[[\"$\",\"div\",null,{\"children\":[\"Just body \
-       content\"]},null,[],{}]]},null,[],{}]]\n\
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"body\",null,{\"children\":[[\"$\",\"div\",null,{\"children\":[\"Just \
+       body content\"]},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
        '>window.srr_stream.push()</script></html>"
 
 let head_with_content () =
@@ -118,7 +121,8 @@ let head_with_content () =
   in
   assert_html app
     ~shell:
-      "<!DOCTYPE html><html><head><title>Titulaso</title><meta charset=\"utf-8\" /></head><script data-payload='0:[null]\n\
+      "<!DOCTYPE html><html><head><title>Titulaso</title><meta charset=\"utf-8\" /></head><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"head\",null,{\"children\":[[\"$\",\"title\",null,{\"children\":[\"Titulaso\"]},null,[],{}],[\"$\",\"meta\",null,{\"charSet\":\"utf-8\"},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
        '>window.srr_stream.push()</script></html>"
 
 let html_inside_a_div () =
@@ -134,7 +138,7 @@ let html_inside_a_fragment () =
   assert_html app
     ~shell:
       "<!DOCTYPE html><html><head></head><div></div><script \
-       data-payload='0:[[[\"$\",\"div\",null,{\"children\":[]},null,[],{}]]]\n\
+       data-payload='0:[[\"$\",\"html\",null,{\"children\":[[\"$\",\"div\",null,{\"children\":[]},null,[],{}]]},null,[],{}]]\n\
        '>window.srr_stream.push()</script></html>"
 
 let html_with_head_like_elements_not_in_head () =
@@ -148,7 +152,8 @@ let html_with_head_like_elements_not_in_head () =
   assert_html app
     ~shell:
       "<!DOCTYPE html><html><head><meta charset=\"utf-8\" /><title>Implicit Head?</title></head><script \
-       data-payload='0:[null,null]\n\
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"meta\",null,{\"charSet\":\"utf-8\"},null,[],{}],[\"$\",\"title\",null,{\"children\":[\"Implicit \
+       Head?\"]},null,[],{}]]},null,[],{}]\n\
        '>window.srr_stream.push()</script></html>"
 
 let html_without_body_and_bootstrap_scripts () =
@@ -157,7 +162,8 @@ let html_without_body_and_bootstrap_scripts () =
     ~shell:
       "<!DOCTYPE html><html><head><link rel=\"modulepreload\" fetchPriority=\"low\" href=\"react\" /><link \
        rel=\"modulepreload\" fetchPriority=\"low\" href=\"react-dom\" /></head><input id=\"sidebar-search-input\" \
-       /><script data-payload='0:[[\"$\",\"input\",null,{\"id\":\"sidebar-search-input\"},null,[],{}]]\n\
+       /><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"input\",null,{\"id\":\"sidebar-search-input\"},null,[],{}]]},null,[],{}]\n\
        '>window.srr_stream.push()</script><script>console.log('hello')</script><script src=\"react\" async=\"\" \
        type=\"module\"></script><script src=\"react-dom\" async=\"\" type=\"module\"></script></html>"
 
@@ -169,10 +175,10 @@ let html_with_body_and_bootstrap_scripts () =
     ~shell:
       "<!DOCTYPE html><html><head><link rel=\"modulepreload\" fetchPriority=\"low\" href=\"react\" /><link \
        rel=\"modulepreload\" fetchPriority=\"low\" href=\"react-dom\" /></head><body><input \
-       id=\"sidebar-search-input\" /><script \
-       data-payload='0:[[\"$\",\"body\",null,{\"children\":[[\"$\",\"input\",null,{\"id\":\"sidebar-search-input\"},null,[],{}]]},null,[],{}]]\n\
+       id=\"sidebar-search-input\" /></body><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"body\",null,{\"children\":[[\"$\",\"input\",null,{\"id\":\"sidebar-search-input\"},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
        '>window.srr_stream.push()</script><script>console.log('hello')</script><script src=\"react\" async=\"\" \
-       type=\"module\"></script><script src=\"react-dom\" async=\"\" type=\"module\"></script></body></html>"
+       type=\"module\"></script><script src=\"react-dom\" async=\"\" type=\"module\"></script></html>"
 
 let input_and_bootstrap_scripts () =
   let app = React.createElement "input" [ React.JSX.String ("id", "id", "sidebar-search-input") ] [] in
@@ -206,17 +212,19 @@ let title_and_meta_populates_to_the_head () =
   assert_html app
     ~shell:
       "<!DOCTYPE html><html><head><title>Hey Yah</title><meta name=\"viewport\" \
-       content=\"width=device-width,initial-scale=1\" /></head><body><script \
-       data-payload='0:[[\"$\",\"body\",null,{\"children\":[null]},null,[],{}]]\n\
-       '>window.srr_stream.push()</script></body></html>"
+       content=\"width=device-width,initial-scale=1\" /></head><body></body><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"body\",null,{\"children\":[[\"$\",\"head\",null,{\"children\":[[\"$\",\"title\",null,{\"children\":[\"Hey \
+       Yah\"]},null,[],{}],[\"$\",\"meta\",null,{\"name\":\"viewport\",\"content\":\"width=device-width,initial-scale=1\"},null,[],{}]]},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
+       '>window.srr_stream.push()</script></html>"
 
 let async_scripts_to_head () =
   let app = html [ body [ script ~async:true ~src:"https://cdn.com/jquery.min.js" () ] ] in
   assert_html app
     ~shell:
-      "<!DOCTYPE html><html><head><script async src=\"https://cdn.com/jquery.min.js\"></script></head><body><script \
-       data-payload='0:[[\"$\",\"body\",null,{\"children\":[null]},null,[],{}]]\n\
-       '>window.srr_stream.push()</script></body></html>"
+      "<!DOCTYPE html><html><head><script async \
+       src=\"https://cdn.com/jquery.min.js\"></script></head><body></body><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"body\",null,{\"children\":[[\"$\",\"script\",null,{\"children\":[],\"async\":true,\"src\":\"https://cdn.com/jquery.min.js\"},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
+       '>window.srr_stream.push()</script></html>"
 
 let async_scripts_gets_deduplicated () =
   let app =
@@ -233,9 +241,10 @@ let async_scripts_gets_deduplicated () =
   (* TODO: Deduplication only works on HTML currently, we don't know if we need the same logic for the model *)
   assert_html app
     ~shell:
-      "<!DOCTYPE html><html><head><script async src=\"https://cdn.com/jquery.min.js\"></script></head><body><script \
-       data-payload='0:[[\"$\",\"body\",null,{\"children\":[null,null,null]},null,[],{}]]\n\
-       '>window.srr_stream.push()</script></body></html>"
+      "<!DOCTYPE html><html><head><script async \
+       src=\"https://cdn.com/jquery.min.js\"></script></head><body></body><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"body\",null,{\"children\":[[\"$\",\"script\",null,{\"children\":[],\"async\":true,\"src\":\"https://cdn.com/jquery.min.js\"},null,[],{}],[\"$\",\"script\",null,{\"children\":[],\"async\":true,\"src\":\"https://cdn.com/jquery.min.js\"},null,[],{}],[\"$\",\"script\",null,{\"children\":[],\"async\":true,\"src\":\"https://cdn.com/jquery.min.js\"},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
+       '>window.srr_stream.push()</script></html>"
 
 let async_scripts_gets_deduplicated_2 () =
   let app =
@@ -253,9 +262,9 @@ let async_scripts_gets_deduplicated_2 () =
   assert_html app
     ~shell:
       "<!DOCTYPE html><html><head><script async src=\"https://cdn.com/duplicated.js\"></script></head><body><script \
-       src=\"https://cdn.com/non-async.js\"></script><script \
-       data-payload='0:[[\"$\",\"body\",null,{\"children\":[null,null,[\"$\",\"script\",null,{\"children\":[],\"async\":false,\"src\":\"https://cdn.com/non-async.js\"},null,[],{}]]},null,[],{}]]\n\
-       '>window.srr_stream.push()</script></body></html>"
+       src=\"https://cdn.com/non-async.js\"></script></body><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"body\",null,{\"children\":[[\"$\",\"script\",null,{\"children\":[],\"async\":true,\"src\":\"https://cdn.com/duplicated.js\"},null,[],{}],[\"$\",\"script\",null,{\"children\":[],\"async\":true,\"src\":\"https://cdn.com/duplicated.js\"},null,[],{}],[\"$\",\"script\",null,{\"children\":[],\"async\":false,\"src\":\"https://cdn.com/non-async.js\"},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
+       '>window.srr_stream.push()</script></html>"
 
 let link_with_rel_and_precedence () =
   let app =
@@ -272,8 +281,9 @@ let link_with_rel_and_precedence () =
   assert_html app
     ~shell:
       "<!DOCTYPE html><html><head><link href=\"https://cdn.com/main.css\" rel=\"stylesheet\" precedence=\"high\" \
-       /></head><body><script data-payload='0:[[\"$\",\"body\",null,{\"children\":[null,null]},null,[],{}]]\n\
-       '>window.srr_stream.push()</script></body></html>"
+       /></head><body></body><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"body\",null,{\"children\":[[\"$\",\"link\",null,{\"href\":\"https://cdn.com/main.css\",\"rel\":\"stylesheet\",\"precedence\":\"high\"},null,[],{}],[\"$\",\"link\",null,{\"href\":\"https://cdn.com/main.css\",\"rel\":\"stylesheet\",\"precedence\":\"low\"},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
+       '>window.srr_stream.push()</script></html>"
 
 let links_gets_pushed_to_the_head () =
   let app =
@@ -294,9 +304,9 @@ let links_gets_pushed_to_the_head () =
     ~shell:
       "<!DOCTYPE html><html><head><link href=\"https://cdn.com/main.css\" rel=\"stylesheet\" precedence=\"low\" \
        /><link href=\"favicon.ico\" rel=\"icon\" /><link href=\"favicon.ico\" rel=\"icon\" /><link \
-       href=\"http://www.example.com/xmlrpc.php\" rel=\"pingback\" /></head><body><script \
-       data-payload='0:[[\"$\",\"body\",null,{\"children\":[null,null,null,null]},null,[],{}]]\n\
-       '>window.srr_stream.push()</script></body></html>"
+       href=\"http://www.example.com/xmlrpc.php\" rel=\"pingback\" /></head><body></body><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"body\",null,{\"children\":[[\"$\",\"link\",null,{\"href\":\"https://cdn.com/main.css\",\"rel\":\"stylesheet\",\"precedence\":\"low\"},null,[],{}],[\"$\",\"link\",null,{\"href\":\"favicon.ico\",\"rel\":\"icon\"},null,[],{}],[\"$\",\"link\",null,{\"href\":\"favicon.ico\",\"rel\":\"icon\"},null,[],{}],[\"$\",\"link\",null,{\"href\":\"http://www.example.com/xmlrpc.php\",\"rel\":\"pingback\"},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
+       '>window.srr_stream.push()</script></html>"
 
 let no_async_scripts_to_remain () =
   let app = html [ body [ script ~async:false ~src:"https://cdn.com/jquery.min.js" () ] ] in
@@ -304,10 +314,10 @@ let no_async_scripts_to_remain () =
     ~shell:
       "<!DOCTYPE html><html><head><link rel=\"modulepreload\" fetchPriority=\"low\" href=\"jquery\" /><link \
        rel=\"modulepreload\" fetchPriority=\"low\" href=\"jquery-mobile\" /></head><body><script \
-       src=\"https://cdn.com/jquery.min.js\"></script><script \
-       data-payload='0:[[\"$\",\"body\",null,{\"children\":[[\"$\",\"script\",null,{\"children\":[],\"async\":false,\"src\":\"https://cdn.com/jquery.min.js\"},null,[],{}]]},null,[],{}]]\n\
+       src=\"https://cdn.com/jquery.min.js\"></script></body><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"body\",null,{\"children\":[[\"$\",\"script\",null,{\"children\":[],\"async\":false,\"src\":\"https://cdn.com/jquery.min.js\"},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
        '>window.srr_stream.push()</script><script src=\"jquery\" async=\"\" type=\"module\"></script><script \
-       src=\"jquery-mobile\" async=\"\" type=\"module\"></script></body></html>"
+       src=\"jquery-mobile\" async=\"\" type=\"module\"></script></html>"
 
 let self_closing_with_dangerously () =
   let app =
@@ -339,7 +349,8 @@ let self_closing_with_dangerously_in_head () =
   assert_html
     ~shell:
       "<!DOCTYPE html><html><head><meta char-set=\"utf-8\" /><style>* { display: none; }</style></head><script \
-       data-payload='0:[null]\n\
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"head\",null,{\"children\":[[\"$\",\"meta\",null,{\"charSet\":\"utf-8\"},null,[],{}],[\"$\",\"style\",null,{\"dangerouslySetInnerHTML\":{\"__html\":\"* \
+       { display: none; }\"}},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
        '>window.srr_stream.push()</script></html>"
     app
 
@@ -368,8 +379,8 @@ let upper_case_component_with_resources () =
     ~shell:
       "<!DOCTYPE html><html><head><link rel=\"stylesheet\" href=\"/styles.css\" precedence=\"default\" /><script \
        src=\"/app.js\" async></script></head><body><div>Page content</div></body><script \
-       data-payload='0:[null,[\"$\",\"body\",null,{\"children\":[[\"$\",\"div\",null,{\"children\":[\"Page \
-       content\"]},null,[],{}]]},null,[],{}]]\n\
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"head\",null,{\"children\":[[\"$\",\"link\",null,{\"rel\":\"stylesheet\",\"href\":\"/styles.css\",\"precedence\":\"default\"},null,[],{}],[\"$\",\"script\",null,{\"children\":[],\"src\":\"/app.js\",\"async\":true},null,[],{}]]},null,[],{}],[\"$\",\"body\",null,{\"children\":[[\"$\",\"div\",null,{\"children\":[\"Page \
+       content\"]},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
        '>window.srr_stream.push()</script></html>"
 
 let hoisted_elements_order_issue () =
@@ -416,10 +427,14 @@ let hoisted_elements_order_issue () =
        Title</title><meta name=\"description\" content=\"Page description\" /><link href=\"/first.css\" \
        rel=\"stylesheet\" /><title>Second Title</title><meta name=\"keywords\" content=\"react, ssr\" /><link \
        href=\"/second.css\" rel=\"stylesheet\" /><meta name=\"author\" content=\"Developer\" /></head><body><div>Body \
-       content</div><script \
-       data-payload='0:[[\"$\",\"body\",null,{\"children\":[null,null,null,null,null,null,null,null,null,null,[\"$\",\"div\",null,{\"children\":[\"Body \
-       content\"]},null,[],{}]]},null,[],{}]]\n\
-       '>window.srr_stream.push()</script></body></html>"
+       content</div></body><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"body\",null,{\"children\":[[\"$\",\"title\",null,{\"children\":[\"First \
+       Title\"]},null,[],{}],[\"$\",\"meta\",null,{\"name\":\"description\",\"content\":\"Page \
+       description\"},null,[],{}],[\"$\",\"link\",null,{\"href\":\"/first.css\",\"rel\":\"stylesheet\"},null,[],{}],[\"$\",\"title\",null,{\"children\":[\"Second \
+       Title\"]},null,[],{}],[\"$\",\"meta\",null,{\"name\":\"keywords\",\"content\":\"react, \
+       ssr\"},null,[],{}],[\"$\",\"link\",null,{\"href\":\"/second.css\",\"rel\":\"stylesheet\"},null,[],{}],[\"$\",\"script\",null,{\"children\":[],\"async\":true,\"src\":\"/first.js\"},null,[],{}],[\"$\",\"link\",null,{\"href\":\"/third.css\",\"rel\":\"stylesheet\",\"precedence\":\"high\"},null,[],{}],[\"$\",\"script\",null,{\"children\":[],\"async\":true,\"src\":\"/second.js\"},null,[],{}],[\"$\",\"meta\",null,{\"name\":\"author\",\"content\":\"Developer\"},null,[],{}],[\"$\",\"div\",null,{\"children\":[\"Body \
+       content\"]},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
+       '>window.srr_stream.push()</script></html>"
 
 let head_preserves_children_order () =
   (* Test that elements inside <head> maintain their original order *)
@@ -449,7 +464,18 @@ let head_preserves_children_order () =
        href=\"/main.css\" rel=\"stylesheet\" /><title>My App</title><meta name=\"viewport\" \
        content=\"width=device-width\" /><script async \
        src=\"/app.js\"></script></head><body><div>Content</div></body><script \
-       data-payload='0:[null,[\"$\",\"body\",null,{\"children\":[[\"$\",\"div\",null,{\"children\":[\"Content\"]},null,[],{}]]},null,[],{}]]\n\
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[[\"$\",\"head\",null,{\"children\":[[\"$\",\"meta\",null,{\"charSet\":\"utf-8\"},null,[],{}],[\"$\",\"style\",null,{\"dangerouslySetInnerHTML\":{\"__html\":\".custom \
+       { color: red; \
+       }\"}},null,[],{}],[\"$\",\"link\",null,{\"href\":\"/main.css\",\"rel\":\"stylesheet\"},null,[],{}],[\"$\",\"title\",null,{\"children\":[\"My \
+       App\"]},null,[],{}],[\"$\",\"meta\",null,{\"name\":\"viewport\",\"content\":\"width=device-width\"},null,[],{}],[\"$\",\"script\",null,{\"children\":[],\"async\":true,\"src\":\"/app.js\"},null,[],{}]]},null,[],{}],[\"$\",\"body\",null,{\"children\":[[\"$\",\"div\",null,{\"children\":[\"Content\"]},null,[],{}]]},null,[],{}]]},null,[],{}]\n\
+       '>window.srr_stream.push()</script></html>"
+
+let html_attributes_are_preserved () =
+  let app = html ~attributes:[ React.JSX.String ("lang", "lang", "en") ] [] in
+  assert_html app
+    ~shell:
+      "<!DOCTYPE html><html lang=\"en\"><head></head><script \
+       data-payload='0:[\"$\",\"html\",null,{\"children\":[],\"lang\":\"en\"},null,[],{}]\n\
        '>window.srr_stream.push()</script></html>"
 
 let tests =
@@ -479,4 +505,5 @@ let tests =
     test "upper_case_component_with_resources" upper_case_component_with_resources;
     test "hoisted_elements_order_issue" hoisted_elements_order_issue;
     test "head_preserves_children_order" head_preserves_children_order;
+    test "html_attributes_are_preserved" html_attributes_are_preserved;
   ]


### PR DESCRIPTION
## Description

This PR keeps the way we reconstruct the html, but changes the model construct.

## Notes

-  We are now collecting the `<html>` attributes as we are rebuilding it.
- All resources now are `Html.node` instead of a custom type, which makes it simpler to maintain and is compatible with the common type we have across the project.
- The head html now is also pushed as a `Html.node option` instead of the custom type `mutable hoisted_head : (Html.attribute_list * Html.element list) option;`
- To keep the model as declared, instead of handling only the `<html>` children with `render_element_to_html ~fiber (React.List children)`, we use `render_regular_element` to render it, but only pass it to the `<html>` only the children:
 ```ocaml
      | Some "html" ->
          Fiber.set_html_tag_attributes ~fiber (ReactDOM.attributes_to_html attributes);
          let%lwt html, model = render_regular_element ~fiber ~key ~tag ~attributes ~children ~inner_html in
          let html_children = match html with Html.Node { children; _ } -> Html.list children | _ -> html in
          Lwt.return (html_children, model)
  ```
- On the `create_model` we don't render `` `Null `` anymore.
