### PR TITLE
Align Suspense with reason-react

### DIFF
--- a/packages/react/src/React.ml
+++ b/packages/react/src/React.ml
@@ -519,7 +519,7 @@ let createContext (initial_value : 'a) : 'a Context.t =
 module Suspense = struct
   let or_react_null = function None -> null | Some x -> x
 
-  let make ?(key = None) ?fallback ?children () =
+  let make ?key ?fallback ?children () =
     Suspense { key; fallback = or_react_null fallback; children = or_react_null children }
 end
 

--- a/packages/react/src/React.mli
+++ b/packages/react/src/React.mli
@@ -610,7 +610,7 @@ end
 val createContext : 'a -> 'a Context.t
 
 module Suspense : sig
-  val make : ?key:string option -> ?fallback:element -> ?children:element -> unit -> element
+  val make : ?key:string -> ?fallback:element -> ?children:element -> unit -> element
 end
 
 type any_promise = Any_promise : 'a Lwt.t -> any_promise


### PR DESCRIPTION
## Description

The `key` on RR Suspense isn't an `option string` but a  `string`.
To align with RR, this PR removes the default value of `Suspense.make`.