### PR TITLE
Allow async in client props

### DIFF
--- a/packages/reactDom/test/test_RSC_html.ml
+++ b/packages/reactDom/test/test_RSC_html.ml
@@ -349,6 +349,36 @@ let client_with_element_props () =
        '>window.srr_stream.push()</script>";
     ]
 
+let client_component_with_async_component () =
+  let children =
+    React.Async_component
+      ( __FUNCTION__,
+        fun () ->
+          let%lwt () = sleep ~ms:10 in
+          Lwt.return (React.string "Async Component") )
+  in
+  let app ~children =
+    React.Upper_case_component
+      ( "app",
+        fun () ->
+          React.Client_component
+            {
+              import_module = "./client.js";
+              import_name = "Client";
+              props = [ ("children", React.Element children) ];
+              client = children;
+            } )
+  in
+  assert_html (app ~children)
+    ~shell:
+      "Async Component<script data-payload='0:[\"$\",\"$3\",null,{\"children\":\"$2\"},null,[],{}]\n\
+       '>window.srr_stream.push()</script>"
+    [
+      "<script data-payload='2:\"$L1\"\n'>window.srr_stream.push()</script>";
+      "<script data-payload='1:\"Async Component\"\n'>window.srr_stream.push()</script>";
+      "<script data-payload='3:I[\"./client.js\",[],\"Client\"]\n'>window.srr_stream.push()</script>";
+    ]
+
 let suspense_with_error () =
   let app () =
     React.Suspense.make ~fallback:(React.string "Loading...")
@@ -641,6 +671,7 @@ let tests =
     test "suspense_without_promise" suspense_without_promise;
     test "with_sleepy_promise" with_sleepy_promise;
     test "client_with_promise_props" client_with_promise_props;
+    test "client_component_with_async_component" client_component_with_async_component;
     test "async_component_with_promise" async_component_with_promise;
     test "suspense_with_error" suspense_with_error;
     test "suspense_with_error_in_async" suspense_with_error_in_async;

--- a/packages/reactDom/test/test_RSC_model.ml
+++ b/packages/reactDom/test/test_RSC_model.ml
@@ -813,6 +813,37 @@ let client_component_with_resources_metadata () =
   Alcotest.(check bool) "should have head with resources" true has_head_with_resources;
   Lwt.return ()
 
+let client_component_with_async_component () =
+  let async_component =
+    React.Async_component
+      ( __FUNCTION__,
+        fun () ->
+          let%lwt () = sleep ~ms:10 in
+          Lwt.return (React.string "Async Component") )
+  in
+  let app ~children =
+    React.Upper_case_component
+      ( "app",
+        fun () ->
+          React.Client_component
+            {
+              import_module = "./client.js";
+              import_name = "Client";
+              props = [ ("children", React.Element children) ];
+              client = children;
+            } )
+  in
+  let output, subscribe = capture_stream () in
+  let%lwt () = ReactServerDOM.render_model ~subscribe (app ~children:async_component) in
+  assert_list_of_strings !output
+    [
+      "1:I[\"./client.js\",[],\"Client\"]\n";
+      "3:\"$L2\"\n";
+      "0:[\"$\",\"$1\",null,{\"children\":\"$3\"},null,[],{}]\n";
+      "2:\"Async Component\"\n";
+    ];
+  Lwt.return ()
+
 let page_with_hoisted_resources () =
   (* Test that resources like scripts and styles are properly hoisted *)
   let app () =
@@ -953,6 +984,7 @@ let tests =
     test "client_without_props" client_without_props;
     test "client_with_element_props" client_with_element_props;
     test "client_with_server_children" client_with_server_children;
+    test "client_component_with_async_component" client_component_with_async_component;
     test "act_with_simple_response" act_with_simple_response;
     test "env_development_adds_debug_info" env_development_adds_debug_info;
     test "act_with_error" act_with_error;


### PR DESCRIPTION
## Description

This PR allows Client Components to have Async Components on their props.
It also get back with the `~pending:1` on render_html that was wrongly removed from it [at this PR](https://github.com/ml-in-barcelona/server-reason-react/pull/312/files#diff-bc0d828b259badab876afc8576ac718be0cabea75f26d2d909e2b03306a1d5f9L829). To avoid any new mistake like this I added a comment explaining why we need such a thing.