### PR TITLE
Add searchParams function to native URL

### DIFF
--- a/packages/url/native/URL.re
+++ b/packages/url/native/URL.re
@@ -218,7 +218,11 @@ let setSearchAsString = (t, searchString) => {
   Uri.with_query(t, Uri.query_of_encoded(searchString));
 };
 let setSearch = Uri.with_query;
-let searchParams = _url => assert(false);
+
+let searchParams = (url): SearchParams.t => {
+  let query = Uri.query(url);
+  query;
+};
 let username = url => {
   switch (Uri.user(url)) {
   /* User can be empty, if the Uri has a password is parsed as Some(""),

--- a/packages/url/test/test_native.re
+++ b/packages/url/test/test_native.re
@@ -175,6 +175,14 @@ let url_tests = (
         "https://:root@app.herokuapp.com/auth",
       );
     }),
+    case("searchParams", () => {
+      let url = URL.makeExn("https://sancho.dev:8080?foo=bar");
+      let searchParams = URL.searchParams(url);
+      assert_entries(
+        URL.SearchParams.entries(searchParams),
+        [|("foo", "bar")|],
+      );
+    }),
   ],
 );
 


### PR DESCRIPTION
## Description

This PR enhances URL support for universal search with the searchParams function. I don't know why we set it as `assert(false)` before. (CC: @davesnx)