### PR TITLE
Remove last element on nested_modules

### DIFF
--- a/packages/server-reason-react-ppx/cram/client-component-on-the-client-nested.t/input.re
+++ b/packages/server-reason-react-ppx/cram/client-component-on-the-client-nested.t/input.re
@@ -12,7 +12,21 @@ let make = (~initial: int, ~lola: lola, ~children: React.element) => {
   </section>;
 };
 
-module Inner = {
+module InnerAfterNested = {
+  module Very_nested = {
+    [@deriving json]
+    type lola = {name: string};
+
+    [@react.client.component]
+    let make = (~initial: int, ~lola: lola, ~children: React.element) => {
+      <section>
+        <h1> {React.string(lola.name)} </h1>
+        <p> {React.int(initial)} </p>
+        <div> children </div>
+      </section>;
+    };
+  };
+
   [@deriving json]
   type lola = {name: string};
 
@@ -24,7 +38,20 @@ module Inner = {
       <div> children </div>
     </section>;
   };
+};
 
+module InnerBeforeNested = {
+  [@deriving json]
+  type lola = {name: string};
+
+  [@react.client.component]
+  let make = (~initial: int, ~lola: lola, ~children: React.element) => {
+    <section>
+      <h1> {React.string(lola.name)} </h1>
+      <p> {React.int(initial)} </p>
+      <div> children </div>
+    </section>;
+  };
   module Very_nested = {
     [@deriving json]
     type lola = {name: string};

--- a/packages/server-reason-react-ppx/cram/client-component-on-the-client-nested.t/run.t
+++ b/packages/server-reason-react-ppx/cram/client-component-on-the-client-nested.t/run.t
@@ -51,12 +51,35 @@
               });
           };
   
-  module Inner = {
+  module InnerAfterNested = {
+    module Very_nested = {
+      [@deriving json]
+      type lola = {name: string};
+  
+      include {
+                [%%raw "// extract-client input.re InnerAfterNested.Very_nested"];
+                [@react.component]
+                let make =
+                    (~initial: int, ~lola: lola, ~children: React.element) =>
+                  <section>
+                    <h1> {React.string(lola.name)} </h1>
+                    <p> {React.int(initial)} </p>
+                    <div> children </div>
+                  </section>;
+                let make_client = props =>
+                  make({
+                    "children": (props##children: React.element),
+                    "lola": [%of_json: lola](props##lola),
+                    "initial": [%of_json: int](props##initial),
+                  });
+              };
+    };
+  
     [@deriving json]
     type lola = {name: string};
   
     include {
-              [%%raw "// extract-client input.re Inner"];
+              [%%raw "// extract-client input.re InnerAfterNested"];
               [@react.component]
               let make = (~initial: int, ~lola: lola, ~children: React.element) =>
                 <section>
@@ -71,13 +94,36 @@
                   "initial": [%of_json: int](props##initial),
                 });
             };
+  };
   
+  module InnerBeforeNested = {
+    [@deriving json]
+    type lola = {name: string};
+  
+    include {
+              [%%raw "// extract-client input.re InnerBeforeNested"];
+              [@react.component]
+              let make = (~initial: int, ~lola: lola, ~children: React.element) =>
+                <section>
+                  <h1> {React.string(lola.name)} </h1>
+                  <p> {React.int(initial)} </p>
+                  <div> children </div>
+                </section>;
+              let make_client = props =>
+                make({
+                  "children": (props##children: React.element),
+                  "lola": [%of_json: lola](props##lola),
+                  "initial": [%of_json: int](props##initial),
+                });
+            };
     module Very_nested = {
       [@deriving json]
       type lola = {name: string};
   
       include {
-                [%%raw "// extract-client input.re Inner.Very_nested"];
+                [%%raw
+                  "// extract-client input.re InnerBeforeNested.Very_nested"
+                ];
                 [@react.component]
                 let make =
                     (~initial: int, ~lola: lola, ~children: React.element) =>

--- a/packages/server-reason-react-ppx/server_reason_react_ppx.ml
+++ b/packages/server-reason-react-ppx/server_reason_react_ppx.ml
@@ -1085,7 +1085,8 @@ let traverse =
       | None -> ()
       | Some name -> nested_module_names <- nested_module_names @ [ name ]);
       let mapped = super#module_binding ctxt module_binding in
-      nested_module_names <- List.tl nested_module_names;
+      let rec remove_last l = match l with [] -> [] | [ _ ] -> [] | hd :: tl -> hd :: remove_last tl in
+      nested_module_names <- remove_last nested_module_names;
       mapped
 
     method! structure_item ctx structure_item =


### PR DESCRIPTION
## Description

I found that we're removing the first module instead of the last from `nested_modules` when traversal of a `module_binding` completes. This breaks when a nested module's client component follows a more deeply nested module.

For example:
```reason
module Inner = {
  module Very_nested = {
    [@deriving json]
    type lola = {name: string};

    [@react.client.component]
    let make = (~initial: int, ~lola: lola, ~children: React.element) => {
      <section>
        <h1> {React.string(lola.name)} </h1>
        <p> {React.int(initial)} </p>
        <div> children </div>
      </section>;
    };
  };

  [@deriving json]
  type lola = {name: string};

  [@react.client.component]
  let make = (~initial: int, ~lola: lola, ~children: React.element) => {
    <section>
      <h1> {React.string(lola.name)} </h1>
      <p> {React.int(initial)} </p>
      <div> children </div>
    </section>;
  };
};
```

That's the output on test:

```diff
     include {
-              [%%raw "// extract-client input.re Inner"];
+              [%%raw "// extract-client input.re Very_nested"];
               [@react.component]
               let make = (~initial: int, ~lola: lola, ~children: React.element) =>
                 <section>
Had 1 error, waiting for filesystem changes...  
``` 
