### PR TITLE
feature: enhance expand_styles_prop to merge className and style props

### DIFF
--- a/packages/expand-styles-attribute/dune
+++ b/packages/expand-styles-attribute/dune
@@ -1,0 +1,6 @@
+(library
+ (name expand_styles_attribute)
+ (public_name server-reason-react.expand-styles-attribute)
+ (libraries ppxlib ppxlib.astlib)
+ (preprocess
+  (pps ppxlib.metaquot)))

--- a/packages/expand-styles-attribute/expand_styles_attribute.ml
+++ b/packages/expand-styles-attribute/expand_styles_attribute.ml
@@ -1,0 +1,58 @@
+let make ~loc attributes =
+  let merge_className current_className (label, expr) =
+    match current_className with
+    | Some (existing_label, existing_expr) ->
+        let merged =
+          match label with
+          | Ppxlib.Optional "className" ->
+              [%expr match [%e expr] with None -> [%e existing_expr] | Some x -> x ^ " " ^ [%e existing_expr]]
+          | _ -> [%expr [%e expr] ^ " " ^ [%e existing_expr]]
+        in
+        Some (existing_label, merged)
+    | None -> Some (label, expr)
+  in
+  let merge_style current_style (label, expr) =
+    match current_style with
+    | Some (existing_label, existing_expr) ->
+        let merged =
+          match label with
+          | Ppxlib.Optional "style" ->
+              [%expr
+                match [%e expr] with
+                | None -> [%e existing_expr]
+                | Some x -> ReactDOM.Style.combine [%e existing_expr] x]
+          | _ -> [%expr ReactDOM.Style.combine [%e existing_expr] [%e expr]]
+        in
+        Some (existing_label, merged)
+    | None -> Some (label, expr)
+  in
+  let handle_styles className style label arg =
+    let className_label, className_expr, style_label, style_expr =
+      match label with
+      | Ppxlib.Labelled "styles" ->
+          (Ppxlib.Labelled "className", [%expr fst [%e arg]], Ppxlib.Labelled "style", [%expr snd [%e arg]])
+      | _ ->
+          ( Ppxlib.Optional "className",
+            [%expr match [%e arg] with None -> None | Some x -> Some (fst x)],
+            Ppxlib.Optional "style",
+            [%expr match [%e arg] with None -> None | Some x -> Some (snd x)] )
+    in
+    (merge_className className (className_label, className_expr), merge_style style (style_label, style_expr))
+  in
+  let rec aux (className, style, other_args) args =
+    match args with
+    | [] ->
+        let rest = List.rev other_args in
+        ([ className; style ] |> List.filter_map Stdlib.Fun.id) @ rest
+    | (label, arg) :: rest -> (
+        match label with
+        | Ppxlib.Labelled "className" | Ppxlib.Optional "className" ->
+            aux (merge_className className (label, arg), style, other_args) rest
+        | Ppxlib.Labelled "style" | Ppxlib.Optional "style" ->
+            aux (className, merge_style style (label, arg), other_args) rest
+        | Ppxlib.Labelled "styles" | Ppxlib.Optional "styles" ->
+            let new_className, new_style = handle_styles className style label arg in
+            aux (new_className, new_style, other_args) rest
+        | _ -> aux (className, style, (label, arg) :: other_args) rest)
+  in
+  aux (None, None, []) attributes

--- a/packages/expand-styles-attribute/test/dune
+++ b/packages/expand-styles-attribute/test/dune
@@ -1,0 +1,9 @@
+(test
+ (name test)
+ (libraries
+  ppxlib
+  ppxlib.astlib
+  alcotest
+  server-reason-react.expand-styles-attribute)
+ (preprocess
+  (pps ppxlib.metaquot)))

--- a/packages/expand-styles-attribute/test/test.ml
+++ b/packages/expand-styles-attribute/test/test.ml
@@ -1,0 +1,87 @@
+let test_expand_styles () =
+  let loc = Ppxlib.Location.none in
+  let expr = [%expr "some-class-name", ReactDOM.Style.make ~backgroundColor:"gainsboro" ()] in
+  let attributes = [ (Ppxlib.Labelled "styles", expr) ] in
+  let expanded_attributes = Expand_styles_attribute.make ~loc:Ppxlib.Location.none attributes in
+
+  List.iter
+    (fun attribute ->
+      match attribute with
+      | ( Ppxlib.Labelled "className",
+          [%expr fst ("some-class-name", ReactDOM.Style.make ~backgroundColor:"gainsboro" ())] ) ->
+          Alcotest.(check pass) "className uses fst" () ()
+      | Ppxlib.Labelled "style", [%expr snd ("some-class-name", ReactDOM.Style.make ~backgroundColor:"gainsboro" ())] ->
+          Alcotest.(check pass) "style uses snd" () ()
+      | _ -> Alcotest.fail "Expanded attributes should be className and style")
+    expanded_attributes
+
+let test_expand_styles_with_previous_className () =
+  let loc = Ppxlib.Location.none in
+  let expr = [%expr "some-class-name", ReactDOM.Style.make ~backgroundColor:"gainsboro" ()] in
+  let attributes = [ (Ppxlib.Labelled "className", [%expr "previous-class-name"]); (Ppxlib.Labelled "styles", expr) ] in
+  let expanded_attributes = Expand_styles_attribute.make ~loc:Ppxlib.Location.none attributes in
+  List.iter
+    (fun attribute ->
+      match attribute with
+      | ( Ppxlib.Labelled "className",
+          [%expr
+            fst ("some-class-name", ReactDOM.Style.make ~backgroundColor:"gainsboro" ()) ^ " " ^ "previous-class-name"]
+        ) ->
+          Alcotest.(check pass) "className uses previous class name" () ()
+      | Ppxlib.Labelled "style", [%expr snd ("some-class-name", ReactDOM.Style.make ~backgroundColor:"gainsboro" ())] ->
+          Alcotest.(check pass) "style uses combine" () ()
+      | _ -> Alcotest.fail "Expanded attributes should be className and style")
+    expanded_attributes
+
+let test_expand_styles_with_previous_style () =
+  let loc = Ppxlib.Location.none in
+  let expr = [%expr "some-class-name", ReactDOM.Style.make ~backgroundColor:"gainsboro" ()] in
+  let attributes = [ (Ppxlib.Labelled "style", [%expr "previous-style"]); (Ppxlib.Labelled "styles", expr) ] in
+  let expanded_attributes = Expand_styles_attribute.make ~loc:Ppxlib.Location.none attributes in
+  List.iter
+    (fun attribute ->
+      match attribute with
+      | ( Ppxlib.Labelled "className",
+          [%expr fst ("some-class-name", ReactDOM.Style.make ~backgroundColor:"gainsboro" ())] ) ->
+          Alcotest.(check pass) "className uses fst" () ()
+      | ( Ppxlib.Labelled "style",
+          [%expr
+            ReactDOM.Style.combine "previous-style"
+              (snd ("some-class-name", ReactDOM.Style.make ~backgroundColor:"gainsboro" ()))] ) ->
+          Alcotest.(check pass) "style uses combine" () ()
+      | _ -> Alcotest.fail "Expanded attributes should be className and style")
+    expanded_attributes
+
+let test_expand_styles_optional () =
+  let loc = Ppxlib.Location.none in
+  let expr = [%expr Some ("some-class-name", ReactDOM.Style.make ~backgroundColor:"gainsboro" ())] in
+  let attributes = [ (Ppxlib.Optional "styles", expr) ] in
+  let expanded_attributes = Expand_styles_attribute.make ~loc:Ppxlib.Location.none attributes in
+  List.iter
+    (fun attribute ->
+      match attribute with
+      | ( Ppxlib.Optional "className",
+          [%expr
+            match Some ("some-class-name", ReactDOM.Style.make ~backgroundColor:"gainsboro" ()) with
+            | None -> None
+            | Some x -> Some (fst x)] ) ->
+          Alcotest.(check pass) "className uses fst" () ()
+      | ( Ppxlib.Optional "style",
+          [%expr
+            match Some ("some-class-name", ReactDOM.Style.make ~backgroundColor:"gainsboro" ()) with
+            | None -> None
+            | Some x -> Some (snd x)] ) ->
+          Alcotest.(check pass) "style uses snd" () ()
+      | _ -> Alcotest.fail "Expanded attributes should be className and style")
+    expanded_attributes
+
+let test title fn = (title, [ Alcotest.test_case "" `Quick fn ])
+
+let () =
+  Alcotest.run "expand_styles_attribute"
+    [
+      test "expand_styles_prop_on_attributes" test_expand_styles;
+      test "expand_styles_with_previous_className" test_expand_styles_with_previous_className;
+      test "expand_styles_with_previous_style" test_expand_styles_with_previous_style;
+      test "expand_styles_optional" test_expand_styles_optional;
+    ]

--- a/packages/server-reason-react-ppx/cram/component-definition.t/run.t
+++ b/packages/server-reason-react-ppx/cram/component-definition.t/run.t
@@ -19,10 +19,10 @@ We need to output ML syntax here, otherwise refmt could not parse it.
             React.createElement "button"
               (Stdlib.List.filter_map Stdlib.Fun.id
                  [
-                   Some (React.JSX.Ref (buttonRef : React.domRef));
                    Some
                      (React.JSX.String
                         ("class", "className", ("FancyButton" : string)));
+                   Some (React.JSX.Ref (buttonRef : React.domRef));
                  ])
               [ children ] )
   end

--- a/packages/server-reason-react-ppx/cram/lower-calls.t/run.t
+++ b/packages/server-reason-react-ppx/cram/lower-calls.t/run.t
@@ -209,11 +209,11 @@
       Stdlib.List.filter_map(
         Stdlib.Fun.id,
         [
-          Some(React.JSX.Ref(ref: React.domRef)),
           Some(
             [@implicit_arity]
             React.JSX.String("class", "className", "FancyButton": string),
           ),
+          Some(React.JSX.Ref(ref: React.domRef)),
         ],
       ),
       [children],

--- a/packages/server-reason-react-ppx/cram/styles.t/input.re
+++ b/packages/server-reason-react-ppx/cram/styles.t/input.re
@@ -1,1 +1,9 @@
+
 <div styles=x />;
+<div styles=?x />;
+<div className="lola" styles=x />;
+<div style={ReactDOM.Style.make(~backgroundColor="gainsboro", ())} styles=x />;
+<div className="lola" style={ReactDOM.Style.make(~backgroundColor="gainsboro", ())} styles=x />;
+<div className="lola" styles=?x />;
+<div style={ReactDOM.Style.make(~backgroundColor="gainsboro", ())} styles=?x />;
+<div className="lola" style={ReactDOM.Style.make(~backgroundColor="gainsboro", ())} styles=?x />;

--- a/packages/server-reason-react-ppx/cram/styles.t/run.t
+++ b/packages/server-reason-react-ppx/cram/styles.t/run.t
@@ -8,3 +8,128 @@ We need to output ML syntax here, otherwise refmt could not parse it.
          Some (React.JSX.Style (snd x : ReactDOM.Style.t));
        ])
     []
+  ;;
+  
+  React.createElement "div"
+    (Stdlib.List.filter_map Stdlib.Fun.id
+       [
+         (match
+            (match x with None -> None | Some x -> Some (fst x) : string option)
+          with
+         | None -> None
+         | Some v -> Some (React.JSX.String ("class", "className", v)));
+         (match
+            (match x with None -> None | Some x -> Some (snd x)
+              : ReactDOM.Style.t option)
+          with
+         | None -> None
+         | Some v -> Some (React.JSX.Style v));
+       ])
+    []
+  ;;
+  
+  React.createElement "div"
+    (Stdlib.List.filter_map Stdlib.Fun.id
+       [
+         Some
+           (React.JSX.String
+              ("class", "className", (fst x ^ " " ^ "lola" : string)));
+         Some (React.JSX.Style (snd x : ReactDOM.Style.t));
+       ])
+    []
+  ;;
+  
+  React.createElement "div"
+    (Stdlib.List.filter_map Stdlib.Fun.id
+       [
+         Some (React.JSX.String ("class", "className", (fst x : string)));
+         Some
+           (React.JSX.Style
+              (ReactDOM.Style.combine
+                 (ReactDOM.Style.make ~backgroundColor:"gainsboro" ())
+                 (snd x)
+                : ReactDOM.Style.t));
+       ])
+    []
+  ;;
+  
+  React.createElement "div"
+    (Stdlib.List.filter_map Stdlib.Fun.id
+       [
+         Some
+           (React.JSX.String
+              ("class", "className", (fst x ^ " " ^ "lola" : string)));
+         Some
+           (React.JSX.Style
+              (ReactDOM.Style.combine
+                 (ReactDOM.Style.make ~backgroundColor:"gainsboro" ())
+                 (snd x)
+                : ReactDOM.Style.t));
+       ])
+    []
+  ;;
+  
+  React.createElement "div"
+    (Stdlib.List.filter_map Stdlib.Fun.id
+       [
+         Some
+           (React.JSX.String
+              ( "class",
+                "className",
+                (match match x with None -> None | Some x -> Some (fst x) with
+                 | None -> "lola"
+                 | Some x -> x ^ " " ^ "lola"
+                  : string) ));
+         (match
+            (match x with None -> None | Some x -> Some (snd x)
+              : ReactDOM.Style.t option)
+          with
+         | None -> None
+         | Some v -> Some (React.JSX.Style v));
+       ])
+    []
+  ;;
+  
+  React.createElement "div"
+    (Stdlib.List.filter_map Stdlib.Fun.id
+       [
+         (match
+            (match x with None -> None | Some x -> Some (fst x) : string option)
+          with
+         | None -> None
+         | Some v -> Some (React.JSX.String ("class", "className", v)));
+         Some
+           (React.JSX.Style
+              (match match x with None -> None | Some x -> Some (snd x) with
+               | None -> ReactDOM.Style.make ~backgroundColor:"gainsboro" ()
+               | Some x ->
+                   ReactDOM.Style.combine
+                     (ReactDOM.Style.make ~backgroundColor:"gainsboro" ())
+                     x
+                : ReactDOM.Style.t));
+       ])
+    []
+  ;;
+  
+  React.createElement "div"
+    (Stdlib.List.filter_map Stdlib.Fun.id
+       [
+         Some
+           (React.JSX.String
+              ( "class",
+                "className",
+                (match match x with None -> None | Some x -> Some (fst x) with
+                 | None -> "lola"
+                 | Some x -> x ^ " " ^ "lola"
+                  : string) ));
+         Some
+           (React.JSX.Style
+              (match match x with None -> None | Some x -> Some (snd x) with
+               | None -> ReactDOM.Style.make ~backgroundColor:"gainsboro" ()
+               | Some x ->
+                   ReactDOM.Style.combine
+                     (ReactDOM.Style.make ~backgroundColor:"gainsboro" ())
+                     x
+                : ReactDOM.Style.t));
+       ])
+    []

--- a/packages/server-reason-react-ppx/dune
+++ b/packages/server-reason-react-ppx/dune
@@ -9,6 +9,7 @@
  (kind ppx_rewriter)
  (libraries
   str
+  server-reason-react.expand-styles-attribute
   compiler-libs.common
   ppxlib
   ppxlib.astlib

--- a/packages/server-reason-react-ppx/test/test.re
+++ b/packages/server-reason-react-ppx/test/test.re
@@ -614,6 +614,81 @@ let server_function_reference_form_data_and_args = () => {
   };
 };
 
+let styles_attribute = () => {
+  let styles = (
+    "some-class-name",
+    ReactDOM.Style.make(~backgroundColor="gainsboro", ()),
+  );
+  let div = <div styles />;
+  assert_string(
+    ReactDOM.renderToStaticMarkup(div),
+    {|<div class="some-class-name" style="background-color:gainsboro"></div>|},
+  );
+};
+
+let styles_attribute_optional = () => {
+  let styles = None;
+  let div = <div ?styles />;
+  assert_string(ReactDOM.renderToStaticMarkup(div), {|<div></div>|});
+};
+
+let styles_attribute_optional_some = () => {
+  let styles =
+    Some((
+      "some-class-name",
+      ReactDOM.Style.make(~backgroundColor="gainsboro", ()),
+    ));
+  let div = <div ?styles />;
+  assert_string(
+    ReactDOM.renderToStaticMarkup(div),
+    {|<div class="some-class-name" style="background-color:gainsboro"></div>|},
+  );
+};
+
+let styles_attribute_optional_some_with_class = () => {
+  let styles =
+    Some((
+      "some-class-name",
+      ReactDOM.Style.make(~backgroundColor="gainsboro", ()),
+    ));
+  let div = <div className="lola" ?styles />;
+  assert_string(
+    ReactDOM.renderToStaticMarkup(div),
+    {|<div class="some-class-name lola" style="background-color:gainsboro"></div>|},
+  );
+};
+
+let styles_attribute_optional_some_with_style = () => {
+  let styles =
+    Some((
+      "some-class-name",
+      ReactDOM.Style.make(~backgroundColor="gainsboro", ()),
+    ));
+  let div = <div style={ReactDOM.Style.make(~color="white", ())} ?styles />;
+  assert_string(
+    ReactDOM.renderToStaticMarkup(div),
+    {|<div class="some-class-name" style="color:white;background-color:gainsboro"></div>|},
+  );
+};
+
+let styles_attribute_optional_some_with_class_and_style = () => {
+  let styles =
+    Some((
+      "some-class-name",
+      ReactDOM.Style.make(~backgroundColor="gainsboro", ()),
+    ));
+  let div =
+    <div
+      className="lola"
+      style={ReactDOM.Style.make(~color="white", ())}
+      ?styles
+    />;
+  assert_string(
+    ReactDOM.renderToStaticMarkup(div),
+    {|<div class="some-class-name lola" style="color:white;background-color:gainsboro"></div>|},
+  );
+};
+
 Alcotest_lwt.run(
   "server-reason-react.ppx",
   [
@@ -655,6 +730,21 @@ Alcotest_lwt.run(
     test("context", context),
     test("context_2", context_2),
     test("multiple_contexts", multiple_contexts),
+    test("styles_attribute", styles_attribute),
+    test("styles_attribute_optional", styles_attribute_optional),
+    test("styles_attribute_optional_some", styles_attribute_optional_some),
+    test(
+      "styles_attribute_optional_some_with_class",
+      styles_attribute_optional_some_with_class,
+    ),
+    test(
+      "styles_attribute_optional_some_with_style",
+      styles_attribute_optional_some_with_style,
+    ),
+    test(
+      "styles_attribute_optional_some_with_class_and_style",
+      styles_attribute_optional_some_with_class_and_style,
+    ),
     test_lwt("server_function", server_function),
     test_lwt("server_function_reference", server_function_reference),
     test_lwt(


### PR DESCRIPTION
## Description

This PR enables the `styles` to work with both the' className' and' style' attributes.

It also fixes an error on expanding `Optional "styles"`, before it was validating the `frt` and `snd` values instead of the `styles` itself. Now, we use an `Option.map` to retrieve the correct values from the option content.
```txt
File "packages/server-reason-react-ppx/test/test.re", line 631, characters 18-24:
631 |   let div = <div ?styles />;
                        ^^^^^^
Error: This expression has type 'a option
       but an expression was expected of type 'b * 'c
Had 1 error, waiting for filesystem changes...     
```

```ocaml
(* Before *)
React.createElementWithKey ~key:None "div"
  (Stdlib.List.filter_map Stdlib.Fun.id
     [
       (match (fst x : string option) with
       | None -> None
       | Some v -> Some (React.JSX.String ("class", "className", v)));
       (match (snd x : ReactDOM.Style.t option) with
       | None -> None
       | Some v -> Some (React.JSX.Style v));
     ])
  []

(* After *)
React.createElementWithKey ~key:None "div"
  (Stdlib.List.filter_map Stdlib.Fun.id
     [
       (match (Option.map (fun x -> fst x) x : string option) with
       | None -> None
       | Some v -> Some (React.JSX.String ("class", "className", v)));
       (match (Option.map (fun x -> snd x) x : ReactDOM.Style.t option) with
       | None -> None
       | Some v -> Some (React.JSX.Style v));
     ])
  []
```

## Examples:

```reason
// Expanding styles prop into className and style props
<div styles=x />;

// Expanding styles prop into className and style props with optional styles
<div styles=?x />;

// Expanding styles prop into className and style props with className already set
<div className="lola" styles=x />;

// Expanding styles prop into className and style props with style already set
<div style={ReactDOM.Style.make(~backgroundColor="gainsboro", ())} styles=x />;

// Expanding styles prop into className and style props with className and style already set
<div className="lola" style={ReactDOM.Style.make(~backgroundColor="gainsboro", ())} styles=x />;

// Expanding styles prop into className and style props with optional styles prop
<div styles=?x />;

// Expanding styles prop into className and style props with optional styles prop and className already set
<div className="lola" styles=?x />;

// Expanding styles prop into className and style props with optional styles prop and style already set
<div style={ReactDOM.Style.make(~backgroundColor="gainsboro", ())} styles=?x />;

// Expanding styles prop into className and style props with optional styles prop and className and style already set
<div className="lola" style={ReactDOM.Style.make(~backgroundColor="gainsboro", ())} styles=?x />;```