### PR TITLE
styles-attribute: expand styles= via CSS accessors instead of fst/snd

### DIFF
--- a/packages/server-reason-react-ppx/cram/optional-prop-shadowed-none.t/run.t
+++ b/packages/server-reason-react-ppx/cram/optional-prop-shadowed-none.t/run.t
@@ -15,11 +15,11 @@ even when a user type in scope shadows `None`. Both the `emit` fast path and the
             Buffer.add_char __buf ' ';
             Buffer.add_string __buf "class";
             Buffer.add_string __buf "=\"";
-            ReactDOM.escape_to_buffer __buf (fst x : string);
+            ReactDOM.escape_to_buffer __buf (CSS.className x : string);
             Buffer.add_char __buf '"';
             Buffer.add_string __buf " style=\"";
             ReactDOM.escape_to_buffer __buf
-              (ReactDOM.Style.to_string (snd x : ReactDOM.Style.t));
+              (ReactDOM.Style.to_string (CSS.styles x : ReactDOM.Style.t));
             Buffer.add_char __buf '"';
             (match
                (match disabled with
@@ -42,8 +42,9 @@ even when a user type in scope shadows `None`. Both the `emit` fast path and the
               (Stdlib.List.filter_map Stdlib.Fun.id
                  [
                    Some
-                     (React.JSX.String ("class", "className", (fst x : string)));
-                   Some (React.JSX.Style (snd x : ReactDOM.Style.t));
+                     (React.JSX.String
+                        ("class", "className", (CSS.className x : string)));
+                   Some (React.JSX.Style (CSS.styles x : ReactDOM.Style.t));
                    (match
                       (match disabled with
                        | true -> None

--- a/packages/server-reason-react-ppx/cram/styles-js.t/run.t
+++ b/packages/server-reason-react-ppx/cram/styles-js.t/run.t
@@ -1,3 +1,3 @@
 Styles expansion should run in Melange mode before JSX is passed through.
   $ ../ppx.sh --output ml -js input.re
-  div ~className:(fst x) ~style:(snd x) ~children:[] () [@JSX]
+  div ~className:(CSS.className x) ~style:(CSS.styles x) ~children:[] () [@JSX]

--- a/packages/server-reason-react-ppx/cram/styles-native.t/run.t
+++ b/packages/server-reason-react-ppx/cram/styles-native.t/run.t
@@ -8,11 +8,11 @@ Styles expansion should run in native mode before DOM JSX is rewritten.
           Buffer.add_char __buf ' ';
           Buffer.add_string __buf "class";
           Buffer.add_string __buf "=\"";
-          ReactDOM.escape_to_buffer __buf (fst x : string);
+          ReactDOM.escape_to_buffer __buf (CSS.className x : string);
           Buffer.add_char __buf '"';
           Buffer.add_string __buf " style=\"";
           ReactDOM.escape_to_buffer __buf
-            (ReactDOM.Style.to_string (snd x : ReactDOM.Style.t));
+            (ReactDOM.Style.to_string (CSS.styles x : ReactDOM.Style.t));
           Buffer.add_char __buf '"';
           Buffer.add_string __buf "></div>";
           ());
@@ -21,8 +21,10 @@ Styles expansion should run in native mode before DOM JSX is rewritten.
           React.createElement "div"
             (Stdlib.List.filter_map Stdlib.Fun.id
                [
-                 Some (React.JSX.String ("class", "className", (fst x : string)));
-                 Some (React.JSX.Style (snd x : ReactDOM.Style.t));
+                 Some
+                   (React.JSX.String
+                      ("class", "className", (CSS.className x : string)));
+                 Some (React.JSX.Style (CSS.styles x : ReactDOM.Style.t));
                ])
             []);
     }

--- a/packages/server-reason-react-ppx/cram/styles.t/run.t
+++ b/packages/server-reason-react-ppx/cram/styles.t/run.t
@@ -9,11 +9,11 @@ We need to output ML syntax here, otherwise refmt could not parse it.
           Buffer.add_char __buf ' ';
           Buffer.add_string __buf "class";
           Buffer.add_string __buf "=\"";
-          ReactDOM.escape_to_buffer __buf (fst x : string);
+          ReactDOM.escape_to_buffer __buf (CSS.className x : string);
           Buffer.add_char __buf '"';
           Buffer.add_string __buf " style=\"";
           ReactDOM.escape_to_buffer __buf
-            (ReactDOM.Style.to_string (snd x : ReactDOM.Style.t));
+            (ReactDOM.Style.to_string (CSS.styles x : ReactDOM.Style.t));
           Buffer.add_char __buf '"';
           Buffer.add_string __buf "></div>";
           ());
@@ -22,8 +22,10 @@ We need to output ML syntax here, otherwise refmt could not parse it.
           React.createElement "div"
             (Stdlib.List.filter_map Stdlib.Fun.id
                [
-                 Some (React.JSX.String ("class", "className", (fst x : string)));
-                 Some (React.JSX.Style (snd x : ReactDOM.Style.t));
+                 Some
+                   (React.JSX.String
+                      ("class", "className", (CSS.className x : string)));
+                 Some (React.JSX.Style (CSS.styles x : ReactDOM.Style.t));
                ])
             []);
     }
@@ -35,7 +37,7 @@ We need to output ML syntax here, otherwise refmt could not parse it.
         (fun __buf ~separators:_ ->
           Buffer.add_string __buf "<div";
           (match
-             (match x with None -> None | Some x -> Some (fst x)
+             (match x with None -> None | Some x -> Some (CSS.className x)
                : string option)
            with
           | None -> ()
@@ -46,7 +48,7 @@ We need to output ML syntax here, otherwise refmt could not parse it.
               ReactDOM.escape_to_buffer __buf (v : string);
               Buffer.add_char __buf '"');
           (match
-             (match x with None -> None | Some x -> Some (snd x)
+             (match x with None -> None | Some x -> Some (CSS.styles x)
                : ReactDOM.Style.t option)
            with
           | None -> ()
@@ -63,13 +65,15 @@ We need to output ML syntax here, otherwise refmt could not parse it.
             (Stdlib.List.filter_map Stdlib.Fun.id
                [
                  (match
-                    (match x with None -> None | Some x -> Some (fst x)
+                    (match x with
+                     | None -> None
+                     | Some x -> Some (CSS.className x)
                       : string option)
                   with
                  | None -> None
                  | Some v -> Some (React.JSX.String ("class", "className", v)));
                  (match
-                    (match x with None -> None | Some x -> Some (snd x)
+                    (match x with None -> None | Some x -> Some (CSS.styles x)
                       : ReactDOM.Style.t option)
                   with
                  | None -> None
@@ -87,11 +91,12 @@ We need to output ML syntax here, otherwise refmt could not parse it.
           Buffer.add_char __buf ' ';
           Buffer.add_string __buf "class";
           Buffer.add_string __buf "=\"";
-          ReactDOM.escape_to_buffer __buf (fst x ^ " " ^ "lola" : string);
+          ReactDOM.escape_to_buffer __buf
+            (CSS.className x ^ " " ^ "lola" : string);
           Buffer.add_char __buf '"';
           Buffer.add_string __buf " style=\"";
           ReactDOM.escape_to_buffer __buf
-            (ReactDOM.Style.to_string (snd x : ReactDOM.Style.t));
+            (ReactDOM.Style.to_string (CSS.styles x : ReactDOM.Style.t));
           Buffer.add_char __buf '"';
           Buffer.add_string __buf "></div>";
           ());
@@ -102,8 +107,10 @@ We need to output ML syntax here, otherwise refmt could not parse it.
                [
                  Some
                    (React.JSX.String
-                      ("class", "className", (fst x ^ " " ^ "lola" : string)));
-                 Some (React.JSX.Style (snd x : ReactDOM.Style.t));
+                      ( "class",
+                        "className",
+                        (CSS.className x ^ " " ^ "lola" : string) ));
+                 Some (React.JSX.Style (CSS.styles x : ReactDOM.Style.t));
                ])
             []);
     }
@@ -117,7 +124,7 @@ We need to output ML syntax here, otherwise refmt could not parse it.
           Buffer.add_char __buf ' ';
           Buffer.add_string __buf "class";
           Buffer.add_string __buf "=\"";
-          ReactDOM.escape_to_buffer __buf (fst x : string);
+          ReactDOM.escape_to_buffer __buf (CSS.className x : string);
           Buffer.add_char __buf '"';
           Buffer.add_string __buf " style=\"";
           ReactDOM.escape_to_buffer __buf
@@ -126,48 +133,7 @@ We need to output ML syntax here, otherwise refmt could not parse it.
                   (("background-color", "backgroundColor", "gainsboro")
                    :: ([] : (string * string * string) list)
                     : ReactDOM.Style.t)
-                  (snd x)
-                 : ReactDOM.Style.t));
-          Buffer.add_char __buf '"';
-          Buffer.add_string __buf "></div>";
-          ());
-      original =
-        (fun () ->
-          React.createElement "div"
-            (Stdlib.List.filter_map Stdlib.Fun.id
-               [
-                 Some (React.JSX.String ("class", "className", (fst x : string)));
-                 Some
-                   (React.JSX.Style
-                      (ReactDOM.Style.combine
-                         (("background-color", "backgroundColor", "gainsboro")
-                          :: ([] : (string * string * string) list)
-                           : ReactDOM.Style.t)
-                         (snd x)
-                        : ReactDOM.Style.t));
-               ])
-            []);
-    }
-  ;;
-  
-  React.Writer
-    {
-      emit =
-        (fun __buf ~separators:_ ->
-          Buffer.add_string __buf "<div";
-          Buffer.add_char __buf ' ';
-          Buffer.add_string __buf "class";
-          Buffer.add_string __buf "=\"";
-          ReactDOM.escape_to_buffer __buf (fst x ^ " " ^ "lola" : string);
-          Buffer.add_char __buf '"';
-          Buffer.add_string __buf " style=\"";
-          ReactDOM.escape_to_buffer __buf
-            (ReactDOM.Style.to_string
-               (ReactDOM.Style.combine
-                  (("background-color", "backgroundColor", "gainsboro")
-                   :: ([] : (string * string * string) list)
-                    : ReactDOM.Style.t)
-                  (snd x)
+                  (CSS.styles x)
                  : ReactDOM.Style.t));
           Buffer.add_char __buf '"';
           Buffer.add_string __buf "></div>";
@@ -179,14 +145,14 @@ We need to output ML syntax here, otherwise refmt could not parse it.
                [
                  Some
                    (React.JSX.String
-                      ("class", "className", (fst x ^ " " ^ "lola" : string)));
+                      ("class", "className", (CSS.className x : string)));
                  Some
                    (React.JSX.Style
                       (ReactDOM.Style.combine
                          (("background-color", "backgroundColor", "gainsboro")
                           :: ([] : (string * string * string) list)
                            : ReactDOM.Style.t)
-                         (snd x)
+                         (CSS.styles x)
                         : ReactDOM.Style.t));
                ])
             []);
@@ -202,13 +168,61 @@ We need to output ML syntax here, otherwise refmt could not parse it.
           Buffer.add_string __buf "class";
           Buffer.add_string __buf "=\"";
           ReactDOM.escape_to_buffer __buf
-            (match match x with None -> None | Some x -> Some (fst x) with
+            (CSS.className x ^ " " ^ "lola" : string);
+          Buffer.add_char __buf '"';
+          Buffer.add_string __buf " style=\"";
+          ReactDOM.escape_to_buffer __buf
+            (ReactDOM.Style.to_string
+               (ReactDOM.Style.combine
+                  (("background-color", "backgroundColor", "gainsboro")
+                   :: ([] : (string * string * string) list)
+                    : ReactDOM.Style.t)
+                  (CSS.styles x)
+                 : ReactDOM.Style.t));
+          Buffer.add_char __buf '"';
+          Buffer.add_string __buf "></div>";
+          ());
+      original =
+        (fun () ->
+          React.createElement "div"
+            (Stdlib.List.filter_map Stdlib.Fun.id
+               [
+                 Some
+                   (React.JSX.String
+                      ( "class",
+                        "className",
+                        (CSS.className x ^ " " ^ "lola" : string) ));
+                 Some
+                   (React.JSX.Style
+                      (ReactDOM.Style.combine
+                         (("background-color", "backgroundColor", "gainsboro")
+                          :: ([] : (string * string * string) list)
+                           : ReactDOM.Style.t)
+                         (CSS.styles x)
+                        : ReactDOM.Style.t));
+               ])
+            []);
+    }
+  ;;
+  
+  React.Writer
+    {
+      emit =
+        (fun __buf ~separators:_ ->
+          Buffer.add_string __buf "<div";
+          Buffer.add_char __buf ' ';
+          Buffer.add_string __buf "class";
+          Buffer.add_string __buf "=\"";
+          ReactDOM.escape_to_buffer __buf
+            (match
+               match x with None -> None | Some x -> Some (CSS.className x)
+             with
              | None -> "lola"
              | Some x -> x ^ " " ^ "lola"
               : string);
           Buffer.add_char __buf '"';
           (match
-             (match x with None -> None | Some x -> Some (snd x)
+             (match x with None -> None | Some x -> Some (CSS.styles x)
                : ReactDOM.Style.t option)
            with
           | None -> ()
@@ -229,13 +243,15 @@ We need to output ML syntax here, otherwise refmt could not parse it.
                       ( "class",
                         "className",
                         (match
-                           match x with None -> None | Some x -> Some (fst x)
+                           match x with
+                           | None -> None
+                           | Some x -> Some (CSS.className x)
                          with
                          | None -> "lola"
                          | Some x -> x ^ " " ^ "lola"
                           : string) ));
                  (match
-                    (match x with None -> None | Some x -> Some (snd x)
+                    (match x with None -> None | Some x -> Some (CSS.styles x)
                       : ReactDOM.Style.t option)
                   with
                  | None -> None
@@ -251,7 +267,7 @@ We need to output ML syntax here, otherwise refmt could not parse it.
         (fun __buf ~separators:_ ->
           Buffer.add_string __buf "<div";
           (match
-             (match x with None -> None | Some x -> Some (fst x)
+             (match x with None -> None | Some x -> Some (CSS.className x)
                : string option)
            with
           | None -> ()
@@ -264,7 +280,9 @@ We need to output ML syntax here, otherwise refmt could not parse it.
           Buffer.add_string __buf " style=\"";
           ReactDOM.escape_to_buffer __buf
             (ReactDOM.Style.to_string
-               (match match x with None -> None | Some x -> Some (snd x) with
+               (match
+                  match x with None -> None | Some x -> Some (CSS.styles x)
+                with
                 | None ->
                     (("background-color", "backgroundColor", "gainsboro")
                      :: ([] : (string * string * string) list)
@@ -285,7 +303,9 @@ We need to output ML syntax here, otherwise refmt could not parse it.
             (Stdlib.List.filter_map Stdlib.Fun.id
                [
                  (match
-                    (match x with None -> None | Some x -> Some (fst x)
+                    (match x with
+                     | None -> None
+                     | Some x -> Some (CSS.className x)
                       : string option)
                   with
                  | None -> None
@@ -293,7 +313,9 @@ We need to output ML syntax here, otherwise refmt could not parse it.
                  Some
                    (React.JSX.Style
                       (match
-                         match x with None -> None | Some x -> Some (snd x)
+                         match x with
+                         | None -> None
+                         | Some x -> Some (CSS.styles x)
                        with
                        | None ->
                            (("background-color", "backgroundColor", "gainsboro")
@@ -320,7 +342,9 @@ We need to output ML syntax here, otherwise refmt could not parse it.
           Buffer.add_string __buf "class";
           Buffer.add_string __buf "=\"";
           ReactDOM.escape_to_buffer __buf
-            (match match x with None -> None | Some x -> Some (fst x) with
+            (match
+               match x with None -> None | Some x -> Some (CSS.className x)
+             with
              | None -> "lola"
              | Some x -> x ^ " " ^ "lola"
               : string);
@@ -328,7 +352,9 @@ We need to output ML syntax here, otherwise refmt could not parse it.
           Buffer.add_string __buf " style=\"";
           ReactDOM.escape_to_buffer __buf
             (ReactDOM.Style.to_string
-               (match match x with None -> None | Some x -> Some (snd x) with
+               (match
+                  match x with None -> None | Some x -> Some (CSS.styles x)
+                with
                 | None ->
                     (("background-color", "backgroundColor", "gainsboro")
                      :: ([] : (string * string * string) list)
@@ -353,7 +379,9 @@ We need to output ML syntax here, otherwise refmt could not parse it.
                       ( "class",
                         "className",
                         (match
-                           match x with None -> None | Some x -> Some (fst x)
+                           match x with
+                           | None -> None
+                           | Some x -> Some (CSS.className x)
                          with
                          | None -> "lola"
                          | Some x -> x ^ " " ^ "lola"
@@ -361,7 +389,9 @@ We need to output ML syntax here, otherwise refmt could not parse it.
                  Some
                    (React.JSX.Style
                       (match
-                         match x with None -> None | Some x -> Some (snd x)
+                         match x with
+                         | None -> None
+                         | Some x -> Some (CSS.styles x)
                        with
                        | None ->
                            (("background-color", "backgroundColor", "gainsboro")
@@ -386,46 +416,49 @@ In Melange mode (-js), ~styles is only expanded on lowercase (DOM) tags.
 Module-qualified components like Foo.Bar keep ~styles as a regular prop (not expanded).
   $ rm -f output.ml temp.ml
   $ ../ppx.sh --output ml -js input.re
-  div ~className:(fst x) ~style:(snd x) ~children:[] () [@JSX];;
+  div ~className:(CSS.className x) ~style:(CSS.styles x) ~children:[] () [@JSX];;
   
   div
-    ?className:(match x with None -> None | Some x -> Some (fst x))
-    ?style:(match x with None -> None | Some x -> Some (snd x))
-    ~children:[] () [@JSX]
-  ;;
-  
-  div ~className:(fst x ^ " " ^ "lola") ~style:(snd x) ~children:[] () [@JSX];;
-  
-  div ~className:(fst x)
-    ~style:
-      (ReactDOM.Style.combine
-         (ReactDOM.Style.make ~backgroundColor:"gainsboro" ())
-         (snd x))
+    ?className:(match x with None -> None | Some x -> Some (CSS.className x))
+    ?style:(match x with None -> None | Some x -> Some (CSS.styles x))
     ~children:[] () [@JSX]
   ;;
   
   div
-    ~className:(fst x ^ " " ^ "lola")
+    ~className:(CSS.className x ^ " " ^ "lola")
+    ~style:(CSS.styles x) ~children:[] () [@JSX]
+  ;;
+  
+  div ~className:(CSS.className x)
     ~style:
       (ReactDOM.Style.combine
          (ReactDOM.Style.make ~backgroundColor:"gainsboro" ())
-         (snd x))
+         (CSS.styles x))
+    ~children:[] () [@JSX]
+  ;;
+  
+  div
+    ~className:(CSS.className x ^ " " ^ "lola")
+    ~style:
+      (ReactDOM.Style.combine
+         (ReactDOM.Style.make ~backgroundColor:"gainsboro" ())
+         (CSS.styles x))
     ~children:[] () [@JSX]
   ;;
   
   div
     ~className:
-      (match match x with None -> None | Some x -> Some (fst x) with
+      (match match x with None -> None | Some x -> Some (CSS.className x) with
       | None -> "lola"
       | Some x -> x ^ " " ^ "lola")
-    ?style:(match x with None -> None | Some x -> Some (snd x))
+    ?style:(match x with None -> None | Some x -> Some (CSS.styles x))
     ~children:[] () [@JSX]
   ;;
   
   div
-    ?className:(match x with None -> None | Some x -> Some (fst x))
+    ?className:(match x with None -> None | Some x -> Some (CSS.className x))
     ~style:
-      (match match x with None -> None | Some x -> Some (snd x) with
+      (match match x with None -> None | Some x -> Some (CSS.styles x) with
       | None -> ReactDOM.Style.make ~backgroundColor:"gainsboro" ()
       | Some x ->
           ReactDOM.Style.combine
@@ -436,11 +469,11 @@ Module-qualified components like Foo.Bar keep ~styles as a regular prop (not exp
   
   div
     ~className:
-      (match match x with None -> None | Some x -> Some (fst x) with
+      (match match x with None -> None | Some x -> Some (CSS.className x) with
       | None -> "lola"
       | Some x -> x ^ " " ^ "lola")
     ~style:
-      (match match x with None -> None | Some x -> Some (snd x) with
+      (match match x with None -> None | Some x -> Some (CSS.styles x) with
       | None -> ReactDOM.Style.make ~backgroundColor:"gainsboro" ()
       | Some x ->
           ReactDOM.Style.combine

--- a/packages/server-reason-react-ppx/test/test.re
+++ b/packages/server-reason-react-ppx/test/test.re
@@ -848,6 +848,11 @@ let text_separator_matches_unoptimized_tree = () => {
   );
 };
 
+module CSS = {
+  let className = ((className, _)) => className;
+  let styles = ((_, styles)) => styles;
+};
+
 let styles_attribute = () => {
   let styles = (
     "some-class-name",

--- a/packages/styles-attribute/styles_attribute.ml
+++ b/packages/styles-attribute/styles_attribute.ml
@@ -42,12 +42,12 @@ let expand_attributes ~loc attributes =
     let className_label, className_expr, style_label, style_expr =
       match label with
       | Ppxlib.Labelled "styles" ->
-          (Ppxlib.Labelled "className", [%expr fst [%e arg]], Ppxlib.Labelled "style", [%expr snd [%e arg]])
+          (Ppxlib.Labelled "className", [%expr CSS.className [%e arg]], Ppxlib.Labelled "style", [%expr CSS.styles [%e arg]])
       | _ ->
           ( Ppxlib.Optional "className",
-            [%expr match [%e arg] with None -> None | Some x -> Some (fst x)],
+            [%expr match [%e arg] with None -> None | Some x -> Some (CSS.className x)],
             Ppxlib.Optional "style",
-            [%expr match [%e arg] with None -> None | Some x -> Some (snd x)] )
+            [%expr match [%e arg] with None -> None | Some x -> Some (CSS.styles x)] )
     in
     (merge_className className (className_label, className_expr), merge_style style (style_label, style_expr))
   in

--- a/packages/styles-attribute/styles_attribute.ml
+++ b/packages/styles-attribute/styles_attribute.ml
@@ -42,7 +42,10 @@ let expand_attributes ~loc attributes =
     let className_label, className_expr, style_label, style_expr =
       match label with
       | Ppxlib.Labelled "styles" ->
-          (Ppxlib.Labelled "className", [%expr CSS.className [%e arg]], Ppxlib.Labelled "style", [%expr CSS.styles [%e arg]])
+          ( Ppxlib.Labelled "className",
+            [%expr CSS.className [%e arg]],
+            Ppxlib.Labelled "style",
+            [%expr CSS.styles [%e arg]] )
       | _ ->
           ( Ppxlib.Optional "className",
             [%expr match [%e arg] with None -> None | Some x -> Some (CSS.className x)],

--- a/packages/styles-attribute/test/test.ml
+++ b/packages/styles-attribute/test/test.ml
@@ -35,7 +35,9 @@ let test_expand_styles () =
   let attributes = [ (Labelled "styles", expr) ] in
   let expanded_attributes = expand_attributes lowercase_jsx_apply attributes in
 
-  assert_list [ (Labelled "className", [%expr fst lola]); (Labelled "style", [%expr snd lola]) ] expanded_attributes
+  assert_list
+    [ (Labelled "className", [%expr CSS.className lola]); (Labelled "style", [%expr CSS.styles lola]) ]
+    expanded_attributes
 
 let test_expand_styles_with_previous_className () =
   let expr = [%expr generated_styles] in
@@ -43,8 +45,8 @@ let test_expand_styles_with_previous_className () =
   let expanded_attributes = expand_attributes lowercase_jsx_apply attributes in
   assert_list
     [
-      (Labelled "className", [%expr fst generated_styles ^ " " ^ "previous-class-name"]);
-      (Labelled "style", [%expr snd generated_styles]);
+      (Labelled "className", [%expr CSS.className generated_styles ^ " " ^ "previous-class-name"]);
+      (Labelled "style", [%expr CSS.styles generated_styles]);
     ]
     expanded_attributes
 
@@ -54,8 +56,8 @@ let test_expand_styles_with_previous_style () =
   let expanded_attributes = expand_attributes lowercase_jsx_apply attributes in
   assert_list
     [
-      (Labelled "className", [%expr fst generated_styles]);
-      (Labelled "style", [%expr ReactDOM.Style.combine "previous-style" (snd generated_styles)]);
+      (Labelled "className", [%expr CSS.className generated_styles]);
+      (Labelled "style", [%expr ReactDOM.Style.combine "previous-style" (CSS.styles generated_styles)]);
     ]
     expanded_attributes
 
@@ -65,8 +67,8 @@ let test_expand_styles_optional () =
   let expanded_attributes = expand_attributes lowercase_jsx_apply attributes in
   assert_list
     [
-      (Optional "className", [%expr match Some generated_styles with None -> None | Some x -> Some (fst x)]);
-      (Optional "style", [%expr match Some generated_styles with None -> None | Some x -> Some (snd x)]);
+      (Optional "className", [%expr match Some generated_styles with None -> None | Some x -> Some (CSS.className x)]);
+      (Optional "style", [%expr match Some generated_styles with None -> None | Some x -> Some (CSS.styles x)]);
     ]
     expanded_attributes
 


### PR DESCRIPTION
The styles= prop expansion destructured the styled-ppx carrier with fst/snd, pinning CSS.styles to a pair across packages. Emit CSS.className / CSS.styles instead