### PR TITLE
Make Provider push/pop exception-safe and async-correct

### DIFF
--- a/packages/reactDom/src/ReactDOM.ml
+++ b/packages/reactDom/src/ReactDOM.ml
@@ -188,9 +188,7 @@ let render_tree buf ~separators ~doctype ~prev_text element : bool =
                API instead. module: " ^ import_module))
     | Provider { children; push; _ } ->
         let pop = push () in
-        let ends_text = render buf prev_text children in
-        pop ();
-        ends_text
+        Fun.protect ~finally:pop (fun () -> render buf prev_text children)
     | Consumer children -> render buf prev_text children
     | Fragment children -> render buf prev_text children
     | List list -> render_children_list buf prev_text list
@@ -455,11 +453,15 @@ let rec render_to_buffer ~env ~stream_context ?(add_doctype = false) buf element
           (Invalid_argument
              ("Client components can't be rendered on the server via renderToStream. Please use the React server \
                components API instead. module: " ^ import_module))
-    | Provider { children; push; _ } ->
+    | Provider { children; push; _ } -> (
         let pop = push () in
-        let%lwt () = render_element children in
-        pop ();
-        Lwt.return ()
+        try%lwt
+          let%lwt () = render_element children in
+          pop ();
+          Lwt.return ()
+        with exn ->
+          pop ();
+          Lwt.reraise exn)
     | Consumer children -> render_element children
     | Fragment children -> render_element children
     | List list -> render_children_list_lwt render_element list

--- a/packages/reactDom/src/ReactServerDOM.ml
+++ b/packages/reactDom/src/ReactServerDOM.ml
@@ -720,11 +720,14 @@ module Model = struct
           let client_props = models_to_payload ~context ~to_chunk ~env props in
           (* Client references are lazy references ("$L<id>"): the client must not block on the module row, it resolves it when the chunk loads. *)
           node ~env ~tag:(lazy_value index) ~key ~props:client_props []
-      | Provider { children; push; _ } ->
+      | Provider { children; push; async_key; async_value } ->
           let pop = push () in
-          let result = turn_element_into_payload ~context ~debug_info children in
-          pop ();
-          result
+          (* [with_value] must span the synchronous serialization: async
+             components below capture the Lwt storage when their promises are
+             created inside it, which happens after this frame's [pop]. *)
+          Fun.protect ~finally:pop (fun () ->
+              Lwt.with_value async_key (Some async_value) (fun () ->
+                  turn_element_into_payload ~context ~debug_info children))
       | Consumer children -> turn_element_into_payload ~context ~debug_info children
     in
     turn_element_into_payload ~context ~debug_info element
@@ -801,11 +804,15 @@ module Model = struct
       | Writer { original; _ } -> go ~debug_info (original ())
       | Fragment children -> go ~debug_info children
       | Consumer children -> go ~debug_info children
-      | Provider { children; push; _ } ->
+      | Provider { children; push; async_key; async_value } -> (
           let pop = push () in
-          let%lwt payload = go ~debug_info children in
-          pop ();
-          Lwt.return payload
+          try%lwt
+            let%lwt payload = Lwt.with_value async_key (Some async_value) (fun () -> go ~debug_info children) in
+            pop ();
+            Lwt.return payload
+          with exn ->
+            pop ();
+            Lwt.reraise exn)
       | (Upper_case_component _ | Async_component _) when debug && Option.is_some debug_info ->
           (* In debug mode only the FIRST component attaches its debug rows to
              the root row; components further down are outlined with their own
@@ -1121,12 +1128,15 @@ let rec client_to_html ~(fiber : Fiber.t) (element : React.element) =
            hydrating client to client-render it. *)
         Lwt.return (html_suspense_client_render ~env:fiber.env ~exn ~fallback:fallback_html))
   | Client_component { client; _ } -> client_to_html ~fiber client
-  | Provider { children; push; async_key; async_value } ->
+  | Provider { children; push; async_key; async_value } -> (
       let pop = push () in
-      let result = Lwt.with_value async_key (Some async_value) (fun () -> client_to_html ~fiber children) in
-      let%lwt result = result in
-      pop ();
-      Lwt.return result
+      try%lwt
+        let%lwt result = Lwt.with_value async_key (Some async_value) (fun () -> client_to_html ~fiber children) in
+        pop ();
+        Lwt.return result
+      with exn ->
+        pop ();
+        Lwt.reraise exn)
   | Consumer children -> client_to_html ~fiber children
 
 and render_lower_case ~fiber ~key:_ ~tag ~attributes ~children ~form_action_id =
@@ -1273,14 +1283,17 @@ let rec render_element_to_html ~(fiber : Fiber.t) ~debug_info (element : React.e
         let index = Stream.push ~context to_chunk in
         let html = html_suspense_placeholder ~fallback:html_fallback index in
         Lwt.return (html, Model.suspense_placeholder ~env:fiber.env ~tag ~key ~fallback:model_fallback index))
-  | Provider { children; push; async_key; async_value } ->
+  | Provider { children; push; async_key; async_value } -> (
       let pop = push () in
-      let result =
-        Lwt.with_value async_key (Some async_value) (fun () -> render_element_to_html ~fiber ~debug_info children)
-      in
-      let%lwt result = result in
-      pop ();
-      Lwt.return result
+      try%lwt
+        let%lwt result =
+          Lwt.with_value async_key (Some async_value) (fun () -> render_element_to_html ~fiber ~debug_info children)
+        in
+        pop ();
+        Lwt.return result
+      with exn ->
+        pop ();
+        Lwt.reraise exn)
   | Consumer children -> render_element_to_html ~fiber ~debug_info children
   | Lower_case_element { key; tag; attributes; children } ->
       render_lower_case_element ~fiber ~debug_info ~key ~tag ~attributes ~children ()

--- a/packages/reactDom/src/ReactServerDOM.ml
+++ b/packages/reactDom/src/ReactServerDOM.ml
@@ -344,6 +344,16 @@ let map_children_with_tree_context f children =
       React.current_tree_context := saved_ctx;
       results
 
+let with_provider_value ~push ~async_key ~async_value fn =
+  let pop = push () in
+  try%lwt
+    let%lwt result = Lwt.with_value async_key (Some async_value) fn in
+    pop ();
+    Lwt.return result
+  with exn ->
+    pop ();
+    Lwt.reraise exn
+
 module Model = struct
   type chunk = Value of json | Debug_ref of json | Component_ref of json | Error of env * React.error
 
@@ -722,9 +732,8 @@ module Model = struct
           node ~env ~tag:(lazy_value index) ~key ~props:client_props []
       | Provider { children; push; async_key; async_value } ->
           let pop = push () in
-          (* [with_value] must span the synchronous serialization: async
-             components below capture the Lwt storage when their promises are
-             created inside it, which happens after this frame's [pop]. *)
+          (* [with_value] must span the sync serialization: async components below capture the Lwt storage when
+             their promises are created inside it — after this frame's pop. *)
           Fun.protect ~finally:pop (fun () ->
               Lwt.with_value async_key (Some async_value) (fun () ->
                   turn_element_into_payload ~context ~debug_info children))
@@ -804,15 +813,8 @@ module Model = struct
       | Writer { original; _ } -> go ~debug_info (original ())
       | Fragment children -> go ~debug_info children
       | Consumer children -> go ~debug_info children
-      | Provider { children; push; async_key; async_value } -> (
-          let pop = push () in
-          try%lwt
-            let%lwt payload = Lwt.with_value async_key (Some async_value) (fun () -> go ~debug_info children) in
-            pop ();
-            Lwt.return payload
-          with exn ->
-            pop ();
-            Lwt.reraise exn)
+      | Provider { children; push; async_key; async_value } ->
+          with_provider_value ~push ~async_key ~async_value (fun () -> go ~debug_info children)
       | (Upper_case_component _ | Async_component _) when debug && Option.is_some debug_info ->
           (* In debug mode only the FIRST component attaches its debug rows to
              the root row; components further down are outlined with their own
@@ -1128,15 +1130,8 @@ let rec client_to_html ~(fiber : Fiber.t) (element : React.element) =
            hydrating client to client-render it. *)
         Lwt.return (html_suspense_client_render ~env:fiber.env ~exn ~fallback:fallback_html))
   | Client_component { client; _ } -> client_to_html ~fiber client
-  | Provider { children; push; async_key; async_value } -> (
-      let pop = push () in
-      try%lwt
-        let%lwt result = Lwt.with_value async_key (Some async_value) (fun () -> client_to_html ~fiber children) in
-        pop ();
-        Lwt.return result
-      with exn ->
-        pop ();
-        Lwt.reraise exn)
+  | Provider { children; push; async_key; async_value } ->
+      with_provider_value ~push ~async_key ~async_value (fun () -> client_to_html ~fiber children)
   | Consumer children -> client_to_html ~fiber children
 
 and render_lower_case ~fiber ~key:_ ~tag ~attributes ~children ~form_action_id =
@@ -1283,17 +1278,8 @@ let rec render_element_to_html ~(fiber : Fiber.t) ~debug_info (element : React.e
         let index = Stream.push ~context to_chunk in
         let html = html_suspense_placeholder ~fallback:html_fallback index in
         Lwt.return (html, Model.suspense_placeholder ~env:fiber.env ~tag ~key ~fallback:model_fallback index))
-  | Provider { children; push; async_key; async_value } -> (
-      let pop = push () in
-      try%lwt
-        let%lwt result =
-          Lwt.with_value async_key (Some async_value) (fun () -> render_element_to_html ~fiber ~debug_info children)
-        in
-        pop ();
-        Lwt.return result
-      with exn ->
-        pop ();
-        Lwt.reraise exn)
+  | Provider { children; push; async_key; async_value } ->
+      with_provider_value ~push ~async_key ~async_value (fun () -> render_element_to_html ~fiber ~debug_info children)
   | Consumer children -> render_element_to_html ~fiber ~debug_info children
   | Lower_case_element { key; tag; attributes; children } ->
       render_lower_case_element ~fiber ~debug_info ~key ~tag ~attributes ~children ()

--- a/packages/reactDom/test/test_RSC_model.ml
+++ b/packages/reactDom/test/test_RSC_model.ml
@@ -1138,6 +1138,51 @@ let nested_context () =
     ];
   Lwt.return ()
 
+let async_component_under_provider_reads_provider_value () =
+  (* The async body resumes after the Provider's sync serialization finished;
+     useContext must still see the Provider's value via Lwt storage. *)
+  let context = React.createContext "default" in
+  let async_reader =
+    React.Async_component
+      ( __FUNCTION__,
+        fun () ->
+          let%lwt () = sleep ~ms:1 in
+          Lwt.return (React.string (React.useContext context)) )
+  in
+  let app =
+    mk_suspense ~fallback:(React.string "Loading...")
+      ~children:(mk_context context ~value:"provided" ~children:async_reader ())
+      ()
+  in
+  let output, subscribe = capture_stream () in
+  let%lwt () = ReactServerDOM.render_model ~subscribe app in
+  assert_list_of_strings !output
+    [
+      "1:\"$Sreact.suspense\"\n";
+      "0:[\"$\",\"$1\",null,{\"children\":\"$L2\",\"fallback\":\"Loading...\"},null,null,1]\n";
+      "2:\"provided\"\n";
+    ];
+  Lwt.return ()
+
+let context_default_survives_provider_child_throw_in_model () =
+  (* A component throwing on the root chain propagates through the Provider
+     frame; the pop must still run so later renders see the default. *)
+  let context = React.createContext "default" in
+  let app =
+    mk_context context ~value:"provided"
+      ~children:(React.Upper_case_component ("Throws", fun () -> raise (Failure "boom")))
+      ()
+  in
+  let output, subscribe = capture_stream () in
+  let%lwt () = ReactServerDOM.render_model ~subscribe app in
+  assert_list_of_strings !output
+    [ "0:E{\"message\":\"Failure(\\\"boom\\\")\",\"stack\":[],\"env\":\"Server\",\"digest\":\"\"}\n" ];
+  let reader = React.Upper_case_component ("Reader", fun () -> React.string (React.useContext context)) in
+  let output, subscribe = capture_stream () in
+  let%lwt () = ReactServerDOM.render_model ~subscribe reader in
+  assert_list_of_strings !output [ "0:\"default\"\n" ];
+  Lwt.return ()
+
 let suspense_with_nested_upper_case () =
   (* Server components are always inlined, matching React.js behavior. Everything resolves in chunk 0. *)
   let inner () = React.Upper_case_component ("Inner", fun () -> React.string "inner-value") in
@@ -1528,6 +1573,8 @@ let tests =
     test "client_component_with_resources_metadata" client_component_with_resources_metadata;
     test "page_with_hoisted_resources" page_with_hoisted_resources;
     test "nested_context" nested_context;
+    test "async_component_under_provider_reads_provider_value" async_component_under_provider_reads_provider_value;
+    test "context_default_survives_provider_child_throw_in_model" context_default_survives_provider_child_throw_in_model;
     test "suspense_with_nested_upper_case" suspense_with_nested_upper_case;
     test "suspense_at_root" suspense_at_root;
     test "suspense_at_root_with_upper_case_children" suspense_at_root_with_upper_case_children;

--- a/packages/reactDom/test/test_RSC_model.ml
+++ b/packages/reactDom/test/test_RSC_model.ml
@@ -1139,8 +1139,7 @@ let nested_context () =
   Lwt.return ()
 
 let async_component_under_provider_reads_provider_value () =
-  (* The async body resumes after the Provider's sync serialization finished;
-     useContext must still see the Provider's value via Lwt storage. *)
+  (* The Suspense keeps the Provider below the root chain, whose serializer awaits children before popping. *)
   let context = React.createContext "default" in
   let async_reader =
     React.Async_component
@@ -1165,8 +1164,8 @@ let async_component_under_provider_reads_provider_value () =
   Lwt.return ()
 
 let context_default_survives_provider_child_throw_in_model () =
-  (* A component throwing on the root chain propagates through the Provider
-     frame; the pop must still run so later renders see the default. *)
+  (* The throw must sit on the root chain: the payload serializer catches component throws before they reach a
+     Provider frame. *)
   let context = React.createContext "default" in
   let app =
     mk_context context ~value:"provided"

--- a/packages/reactDom/test/test_renderToString.ml
+++ b/packages/reactDom/test/test_renderToString.ml
@@ -67,8 +67,6 @@ let suspense_fallback_on_error () =
   assert_string html "<!--$!--><div>fallback</div><!--/$-->"
 
 let context_default_survives_provider_child_throw () =
-  (* A throw under a Provider is swallowed by the Suspense boundary; the
-     Provider's popped value must not leak into later renders. *)
   let context = React.createContext "default" in
   let first =
     React.Suspense

--- a/packages/reactDom/test/test_renderToString.ml
+++ b/packages/reactDom/test/test_renderToString.ml
@@ -66,6 +66,26 @@ let suspense_fallback_on_error () =
   let html = ReactDOM.renderToString el in
   assert_string html "<!--$!--><div>fallback</div><!--/$-->"
 
+let context_default_survives_provider_child_throw () =
+  (* A throw under a Provider is swallowed by the Suspense boundary; the
+     Provider's popped value must not leak into later renders. *)
+  let context = React.createContext "default" in
+  let first =
+    React.Suspense
+      {
+        key = None;
+        children =
+          React.Context.provider context
+            (React.Context.makeProps ~value:"provided"
+               ~children:(React.Upper_case_component ("Throws", fun () -> raise (Failure "boom")))
+               ());
+        fallback = Some (React.string "fallback");
+      }
+  in
+  assert_string (ReactDOM.renderToString first) "<!--$!-->fallback<!--/$-->";
+  let second = React.Upper_case_component ("Reader", fun () -> React.string (React.useContext context)) in
+  assert_string (ReactDOM.renderToString second) "default"
+
 let inline_style_escaping () =
   (* A quoted CSS value must be escaped so it doesn't terminate the style="..."
      attribute early and drop the following custom properties. *)
@@ -108,6 +128,7 @@ let tests =
     test "text_after_element_with_text_child" text_after_element_with_text_child;
     test "suspense children render exactly once" suspense_children_render_once;
     test "suspense renders fallback on error" suspense_fallback_on_error;
+    test "context default survives provider child throw" context_default_survives_provider_child_throw;
     test "inline style escaping" inline_style_escaping;
     test "inline style empty value skipped" inline_style_empty_value_skipped;
     test "defaultChecked/defaultValue render as checked/value" default_checked_and_value_render_as_checked_and_value;


### PR DESCRIPTION
## Problem

`React.createContext` keeps the current provider value in a module-level mutable ref, set via paired `push`/`pop` closures. Two bugs:

1. **No exception safety.** Every render path did `push (); ...; pop ()` with nothing guaranteeing `pop` on a throw. In the sync renderer, the enclosing Suspense handler catches the exception and keeps rendering — so a single throw under a Provider permanently changed that context's process-global default for every subsequent request (cross-request bleed, e.g. a session context leaking between users).
2. **Wrong value in async server components (RSC model path).** `Model.turn_element_into_payload`'s Provider branch used only `push`/`pop`, unlike the HTML paths which also use `Lwt.with_value`. Async components under it run after `pop ()` executed, so `useContext` read the outer/default value in `render_model`.

## Fix

- All six Provider render sites now run `pop` exception-safely: `Fun.protect ~finally` on the sync paths, and a shared `with_provider_value` helper (push, `Lwt.with_value`, pop on both arms via `Lwt.reraise`) on the three Lwt sites in `ReactServerDOM.ml`; the single Lwt site in `ReactDOM.ml` inlines the same shape.
- The two RSC model sites additionally wrap children serialization in `Lwt.with_value async_key (Some async_value)`, matching the HTML paths, so async components capture the provided value.
- The mutable fallback in `useContext` remains — it is load-bearing for sync renders, which never set Lwt storage.

## Tests (written first, failing at base)

- `context default survives provider child throw` (renderToString): throw under Provider inside Suspense, then a second render asserts the default was restored (previously observed the leaked value).
- `async_component_under_provider_reads_provider_value` (render_model): async component resuming after the Provider frame now reads the provided value (previously read the default).
- `context_default_survives_provider_child_throw_in_model`: root-chain throw through a Provider frame; later render sees the default.

`make build`, `make test` (366 tests), `make format-check` all green; Flight fixtures untouched.

