### PR TITLE
Benchmark renderToStream and fully-drained RSC render_html in CI

### DIFF
--- a/benchmark/bench.ml
+++ b/benchmark/bench.ml
@@ -159,6 +159,30 @@ let () =
       measure_benchmark_lwt ~name:"rsc/table/500" (fun () ->
           let%lwt html, _subscribe = ReactServerDOM.render_html (Table.Table500.make (Table.Table500.makeProps ())) in
           Lwt.return html);
+      measure_benchmark_lwt ~name:"streaming/renderToStream/wide100" (fun () ->
+          let%lwt stream, _abort =
+            ReactDOM.renderToStream ~env:`Prod (WideTree.Wide100.make (WideTree.Wide100.makeProps ()))
+          in
+          Lwt_stream.iter (fun _ -> ()) stream);
+      measure_benchmark_lwt ~name:"streaming/renderToStream/suspense" (fun () ->
+          let%lwt stream, _abort =
+            ReactDOM.renderToStream ~env:`Prod (SuspenseTree.make (SuspenseTree.makeProps ()))
+          in
+          Lwt_stream.iter (fun _ -> ()) stream);
+      measure_benchmark_lwt ~name:"rsc/render_html/wide100" (fun () ->
+          let%lwt _shell, subscribe =
+            ReactServerDOM.render_html ~env:`Prod (WideTree.Wide100.make (WideTree.Wide100.makeProps ()))
+          in
+          subscribe (fun _ -> Lwt.return ()));
+      measure_benchmark_lwt ~name:"rsc/render_html/suspense" (fun () ->
+          let%lwt _shell, subscribe =
+            ReactServerDOM.render_html ~env:`Prod (SuspenseTree.make (SuspenseTree.makeProps ()))
+          in
+          subscribe (fun _ -> Lwt.return ()));
+      measure_benchmark_lwt ~name:"rsc/render_model/wide100" (fun () ->
+          ReactServerDOM.render_model ~env:`Prod
+            ~subscribe:(fun _ -> Lwt.return ())
+            (WideTree.Wide100.make (WideTree.Wide100.makeProps ())));
     ]
   in
 

--- a/benchmark/bench.ml
+++ b/benchmark/bench.ml
@@ -165,9 +165,7 @@ let () =
           in
           Lwt_stream.iter (fun _ -> ()) stream);
       measure_benchmark_lwt ~name:"streaming/renderToStream/suspense" (fun () ->
-          let%lwt stream, _abort =
-            ReactDOM.renderToStream ~env:`Prod (SuspenseTree.make (SuspenseTree.makeProps ()))
-          in
+          let%lwt stream, _abort = ReactDOM.renderToStream ~env:`Prod (SuspenseTree.make (SuspenseTree.makeProps ())) in
           Lwt_stream.iter (fun _ -> ()) stream);
       measure_benchmark_lwt ~name:"rsc/render_html/wide100" (fun () ->
           let%lwt _shell, subscribe =

--- a/benchmark/scenarios/SuspenseTree.re
+++ b/benchmark/scenarios/SuspenseTree.re
@@ -1,8 +1,4 @@
-/* Scenario: Suspense Tree
-      Multiple Suspense boundaries whose async components resolve immediately
-      (Lwt.return based, no sleeps) so benchmarks measure render cost only.
-      Purpose: Exercise the streaming/RSC Suspense machinery
-   */
+/* Async sections resolve via Lwt.return on purpose: the benchmark measures render cost, not waiting. */
 
 module Item = {
   [@react.component]
@@ -33,21 +29,17 @@ module AsyncSection = {
 };
 
 module Boundaries3 = {
+  let section = (~label, ~offset) =>
+    <React.Suspense fallback={<span> {React.string(label)} </span>}>
+      <AsyncSection offset />
+    </React.Suspense>;
+
   [@react.component]
   let make = () => {
     <div className="grid gap-4 p-4">
-      <React.Suspense
-        fallback={<span> {React.string("Loading section 1")} </span>}>
-        <AsyncSection offset=0 />
-      </React.Suspense>
-      <React.Suspense
-        fallback={<span> {React.string("Loading section 2")} </span>}>
-        <AsyncSection offset=10 />
-      </React.Suspense>
-      <React.Suspense
-        fallback={<span> {React.string("Loading section 3")} </span>}>
-        <AsyncSection offset=20 />
-      </React.Suspense>
+      {section(~label="Loading section 1", ~offset=0)}
+      {section(~label="Loading section 2", ~offset=10)}
+      {section(~label="Loading section 3", ~offset=20)}
     </div>;
   };
 };

--- a/benchmark/scenarios/SuspenseTree.re
+++ b/benchmark/scenarios/SuspenseTree.re
@@ -1,0 +1,56 @@
+/* Scenario: Suspense Tree
+      Multiple Suspense boundaries whose async components resolve immediately
+      (Lwt.return based, no sleeps) so benchmarks measure render cost only.
+      Purpose: Exercise the streaming/RSC Suspense machinery
+   */
+
+module Item = {
+  [@react.component]
+  let make = (~id) => {
+    <li className="p-2 border-b">
+      {React.string(Printf.sprintf("Async item %d", id))}
+    </li>;
+  };
+};
+
+module AsyncSection = {
+  [@react.async.component]
+  let make = (~offset) => {
+    Lwt.return(
+      <ul className="divide-y">
+        {React.array(
+           Array.init(
+             10,
+             i => {
+               let id = offset + i;
+               <Item key={Int.to_string(id)} id />;
+             },
+           ),
+         )}
+      </ul>,
+    );
+  };
+};
+
+module Boundaries3 = {
+  [@react.component]
+  let make = () => {
+    <div className="grid gap-4 p-4">
+      <React.Suspense
+        fallback={<span> {React.string("Loading section 1")} </span>}>
+        <AsyncSection offset=0 />
+      </React.Suspense>
+      <React.Suspense
+        fallback={<span> {React.string("Loading section 2")} </span>}>
+        <AsyncSection offset=10 />
+      </React.Suspense>
+      <React.Suspense
+        fallback={<span> {React.string("Loading section 3")} </span>}>
+        <AsyncSection offset=20 />
+      </React.Suspense>
+    </div>;
+  };
+};
+
+[@react.component]
+let make = () => <Boundaries3 />;

--- a/benchmark/scenarios/dune
+++ b/benchmark/scenarios/dune
@@ -1,6 +1,7 @@
 (library
  (name benchmark_scenarios)
  (libraries
+  lwt
   server-reason-react.react
   server-reason-react.reactDom
   server-reason-react.js)


### PR DESCRIPTION
CI gates performance regressions via github-action-benchmark + `scripts/compare-benchmarks.mjs`, but the streamed paths had gaps: `render_html` was measured shell-only (the returned `subscribe` stream was never drained), and `ReactDOM.renderToStream` and Suspense-shaped trees were not measured at all. The repo's own `benchmark/perf-work/PERF_NEXT.md` defers its H5 optimization "unless a streaming benchmark is added" — this is that prerequisite.

## Changes

- 5 new fully-draining benchmarks in `bench.exe` (all with explicit `~env:`Prod` so numbers don't shift with default changes):
  - `streaming/renderToStream/wide100`, `streaming/renderToStream/suspense`
  - `rsc/render_html/wide100`, `rsc/render_html/suspense` (drained via `subscribe`)
  - `rsc/render_model/wide100`
- New `benchmark/scenarios/SuspenseTree.re`: 3 Suspense boundaries with immediately-resolving async components (`Lwt.return`, no sleeps — measures render cost, not waiting).
- Existing entries untouched; the pre-existing shell-only `rsc/*` entries coexist under distinct names.

## Notes

- `scripts/compare-benchmarks.mjs` handles baseline-missing names gracefully (renders them as "new" and continues) — verified by reading the script.
- The first CI run on main after merge seeds the baseline for the new names; regressions gate from the second run onward.
- Local runs on a loaded box showed noise comparable to the pre-existing lwt benchmarks; nothing specific to the new measurements.

`make bench` (all rows non-zero), `make bench-json` (43 valid entries), `make build`, `make test`, `make format-check` all green.
