### PR TITLE
Key React.cache by value for primitives, identity for blocks

### DIFF
--- a/packages/react/src/React.ml
+++ b/packages/react/src/React.ml
@@ -592,7 +592,21 @@ end
 
 module Cache = struct
   type cache_entry = Ok of Obj.t | Error of exn
-  type fn_cache = (Obj.t, cache_entry) Hashtbl.t
+
+  (* React's cache keys arguments like a JS Map: primitives compare by value,
+     everything else by reference. [Obj.tag] is inspected before any
+     [Obj.obj], and values are only read back at their tag-certified type
+     (string/float), so no representation is reinterpreted. *)
+  let same_arg (a : Obj.t) (b : Obj.t) =
+    a == b
+    || Obj.is_block a && Obj.is_block b
+       &&
+       let tag_a = Obj.tag a in
+       tag_a = Obj.tag b
+       && ((tag_a = Obj.string_tag && String.equal (Obj.obj a) (Obj.obj b))
+          || (tag_a = Obj.double_tag && Float.equal (Obj.obj a) (Obj.obj b)))
+
+  type fn_cache = (Obj.t * cache_entry) list Stdlib.ref
   type request_cache = (int, fn_cache) Hashtbl.t
 
   let async_key : request_cache Lwt.key = Lwt.new_key ()
@@ -623,21 +637,21 @@ let cache fn =
           match Hashtbl.find_opt cache_map fn_id with
           | Some cache -> cache
           | None ->
-              let cache = Hashtbl.create 8 in
+              let cache = ref [] in
               Hashtbl.add cache_map fn_id cache;
               cache
         in
         let arg_key = Obj.repr arg in
-        match Hashtbl.find_opt fn_cache arg_key with
-        | Some (Cache.Ok value) -> Obj.obj value
-        | Some (Cache.Error error) -> raise error
+        match List.find_opt (fun (key, _) -> Cache.same_arg key arg_key) !fn_cache with
+        | Some (_, Cache.Ok value) -> Obj.obj value
+        | Some (_, Cache.Error error) -> raise error
         | None -> (
             try
               let result = fn arg in
-              Hashtbl.add fn_cache arg_key (Cache.Ok (Obj.repr result));
+              fn_cache := (arg_key, Cache.Ok (Obj.repr result)) :: !fn_cache;
               result
             with exn ->
-              Hashtbl.add fn_cache arg_key (Cache.Error exn);
+              fn_cache := (arg_key, Cache.Error exn) :: !fn_cache;
               raise exn))
 
 let useContext (context : 'a Context.t) =

--- a/packages/react/src/React.ml
+++ b/packages/react/src/React.ml
@@ -593,10 +593,8 @@ end
 module Cache = struct
   type cache_entry = Ok of Obj.t | Error of exn
 
-  (* React's cache keys arguments like a JS Map: primitives compare by value,
-     everything else by reference. [Obj.tag] is inspected before any
-     [Obj.obj], and values are only read back at their tag-certified type
-     (string/float), so no representation is reinterpreted. *)
+  (* React-parity keying: primitives (int/string/float) by value, everything else by reference. Every [Obj.obj] is
+     guarded by an [Obj.tag] check, so no representation is reinterpreted. *)
   let same_arg (a : Obj.t) (b : Obj.t) =
     a == b
     || Obj.is_block a && Obj.is_block b

--- a/packages/react/src/React.mli
+++ b/packages/react/src/React.mli
@@ -678,7 +678,12 @@ exception Suspend of any_promise
 
 val memo : 'component -> 'component
 val memoCustomCompareProps : 'component -> ('props -> 'props -> bool) -> 'component
+
 val cache : ('a -> 'b) -> 'a -> 'b
+(** Request-scoped memoization: within [Cache.with_request_cache] (or its async variant) the wrapped function runs at
+    most once per distinct argument. Arguments are compared like React's cache: primitives (ints, strings, floats) by
+    value, all other values by physical identity. *)
+
 val useContext : 'a Context.t -> 'a
 val useState : (unit -> 'state) -> 'state * (('state -> 'state) -> unit)
 val useMemo : (unit -> 'a) -> 'a

--- a/packages/react/test/test_react.ml
+++ b/packages/react/test/test_react.ml
@@ -223,6 +223,68 @@ let cache_error_same_instance () =
           Alcotest.(check bool) "is original exception" true (e1 == original_exn)
       | _ -> Alcotest.fail "expected exceptions to be captured")
 
+let cache_arg_containing_closure_does_not_crash () =
+  let calls = ref 0 in
+  let cached =
+    React.cache (fun (f : int -> int) ->
+        calls := !calls + 1;
+        f 1)
+  in
+  let g = fun x -> x + 1 in
+  let h = fun x -> x + 2 in
+  React.Cache.with_request_cache (fun () ->
+      ignore (cached g);
+      ignore (cached h);
+      ignore (cached g);
+      (* many distinct closures so a structural store would collide buckets
+         and raise "compare: functional value" *)
+      for i = 3 to 22 do
+        ignore (cached (fun x -> x + i))
+      done);
+  assert_int !calls 22
+
+type cache_record = { a : int; b : string }
+
+let cache_structurally_equal_records_miss () =
+  let calls = ref 0 in
+  let cached =
+    React.cache (fun (record : cache_record) ->
+        calls := !calls + 1;
+        record.a + String.length record.b)
+  in
+  (* [Sys.opaque_identity] prevents the compiler from statically sharing the
+     two structurally-equal records: the test needs distinct allocations *)
+  let make_record () = { a = Sys.opaque_identity 1; b = "one" } in
+  React.Cache.with_request_cache (fun () ->
+      ignore (cached (make_record ()));
+      ignore (cached (make_record ())));
+  assert_int !calls 2
+
+let cache_same_record_hits () =
+  let calls = ref 0 in
+  let cached =
+    React.cache (fun (record : cache_record) ->
+        calls := !calls + 1;
+        record.a + String.length record.b)
+  in
+  let record = { a = 1; b = "one" } in
+  React.Cache.with_request_cache (fun () ->
+      ignore (cached record);
+      ignore (cached record));
+  assert_int !calls 1
+
+let cache_float_args_hit_by_value () =
+  let calls = ref 0 in
+  let cached =
+    React.cache (fun value ->
+        calls := !calls + 1;
+        value +. 1.)
+  in
+  React.Cache.with_request_cache (fun () ->
+      ignore (cached 1.5);
+      ignore (cached 1.5));
+  assert_int !calls 1
+
 let lwt_test title fn = Alcotest.test_case title `Quick (fun () -> Lwt_main.run (fn ()))
 
 let cache_async_hits_within_request () =
@@ -342,6 +404,10 @@ let tests =
       test "cache errors mixed with success" cache_error_mixed_with_success;
       test "cache errors reset between requests" cache_error_resets_between_requests;
       test "cache errors same instance" cache_error_same_instance;
+      test "cache arg containing closure does not crash" cache_arg_containing_closure_does_not_crash;
+      test "cache structurally equal records miss" cache_structurally_equal_records_miss;
+      test "cache same record hits" cache_same_record_hits;
+      test "cache float args hit by value" cache_float_args_hit_by_value;
       lwt_test "cache async hits within request" cache_async_hits_within_request;
       lwt_test "cache async resets between requests" cache_async_resets_between_requests;
       lwt_test "cache async concurrent isolation" cache_async_concurrent_isolation;

--- a/packages/react/test/test_react.ml
+++ b/packages/react/test/test_react.ml
@@ -236,8 +236,7 @@ let cache_arg_containing_closure_does_not_crash () =
       ignore (cached g);
       ignore (cached h);
       ignore (cached g);
-      (* many distinct closures so a structural store would collide buckets
-         and raise "compare: functional value" *)
+      (* enough distinct closures that a structural store would compare functional values and raise *)
       for i = 3 to 22 do
         ignore (cached (fun x -> x + i))
       done);
@@ -252,8 +251,7 @@ let cache_structurally_equal_records_miss () =
         calls := !calls + 1;
         record.a + String.length record.b)
   in
-  (* [Sys.opaque_identity] prevents the compiler from statically sharing the
-     two structurally-equal records: the test needs distinct allocations *)
+  (* [Sys.opaque_identity] stops the compiler from statically sharing the two structurally-equal records *)
   let make_record () = { a = Sys.opaque_identity 1; b = "one" } in
   React.Cache.with_request_cache (fun () ->
       ignore (cached (make_record ()));


### PR DESCRIPTION
## Problem

`React.cache` keyed its per-request memo table on `Obj.repr arg` in a generic `Hashtbl` — structural `Hashtbl.hash` plus polymorphic equality on `Obj.t`. Consequences:

1. **Runtime crash**: if a cached function's argument contains a closure anywhere (records with callbacks are idiomatic), polymorphic equality raises `Invalid_argument "compare: functional value"` at request time on hash collision. Reproduced deterministically in the new test at the base commit (raised from `Hashtbl.find_opt`).
2. **Silent misbehavior**: mutable arguments hash differently over time, defeating or corrupting the cache; cyclic values loop.

React's `cache` keys a Map per argument: primitives by value, objects by reference.

## Fix

The per-fn store is now an association list with React-parity key equality (`same_arg`): physical equality first (covers immediates by value), then tag-checked value equality for strings and floats only. Every `Obj.obj` read is preceded by the corresponding `Obj.tag` check — no representation is reinterpreted, consistent with the `Physical_key` discipline in `ReactServerDOM.ml`. The assoc list is request-scoped with few entries per fn (same pattern and justification as `written_promises`).

Semantics change (React parity): structurally-equal-but-distinct blocks now MISS (previously hit). Strings/ints/floats keep value semantics — all existing cache tests pass unmodified. Callers in demo/ were checked: the only hit-dependent caller uses string args (unaffected).

## Tests

Closure-containing args no longer crash (incl. a 20-closure collision loop that crashed at base); structural twins miss; same block hits; float args hit by value. Doc comment added to `React.mli`.

`make build`, `make test`, `make format-check` all green.
