### PR TITLE
Fix URL.makeWith resolution and SearchParams join/set semantics

### DIFF
--- a/packages/url/native/URL.re
+++ b/packages/url/native/URL.re
@@ -38,22 +38,15 @@ module SearchParams = {
     List.filter(((key, _value)) => key != string, t);
   };
 
-  let set = (t, newKey, newValue) => {
-    let (rev, replaced) =
-      List.fold_left(
-        ((acc, replaced), (key, value)) =>
-          if (key == newKey) {
-            replaced
-              ? (acc, replaced) : ([(key, [newValue]), ...acc], true);
-          } else {
-            ([(key, value), ...acc], replaced);
-          },
-        ([], false),
-        t,
-      );
-    let t = List.rev(rev);
-    replaced ? t : List.append(t, [(newKey, [newValue])]);
-  };
+  let rec set = (t, newKey, newValue) =>
+    switch (t) {
+    | [] => [(newKey, [newValue])]
+    | [(key, _), ...rest] when key == newKey => [
+        (key, [newValue]),
+        ...delete(rest, newKey),
+      ]
+    | [pair, ...rest] => [pair, ...set(rest, newKey, newValue)]
+    };
 
   let forEach = (t, fn) => {
     List.iter(

--- a/packages/url/native/URL.re
+++ b/packages/url/native/URL.re
@@ -2,7 +2,7 @@ module SearchParams = {
   /* value is a list of strings on Uri, but it's represented as string on the browser
      we keep the type as a list, but each method it needs the value we "joinValue" */
   type value = list(string);
-  let joinValue = value => String.concat("", value);
+  let joinValue = value => String.concat(",", value);
 
   type t = list((string, value));
 
@@ -39,15 +39,20 @@ module SearchParams = {
   };
 
   let set = (t, newKey, newValue) => {
-    List.map(
-      ((key, value)) =>
-        if (key == newKey) {
-          (key, [newValue]);
-        } else {
-          (key, value);
-        },
-      t,
-    );
+    let (rev, replaced) =
+      List.fold_left(
+        ((acc, replaced), (key, value)) =>
+          if (key == newKey) {
+            replaced
+              ? (acc, replaced) : ([(key, [newValue]), ...acc], true);
+          } else {
+            ([(key, value), ...acc], replaced);
+          },
+        ([], false),
+        t,
+      );
+    let t = List.rev(rev);
+    replaced ? t : List.append(t, [(newKey, [newValue])]);
   };
 
   let forEach = (t, fn) => {
@@ -64,7 +69,7 @@ module SearchParams = {
     List.find_map(
       ((key, value)) =>
         if (key == string) {
-          List.nth_opt(value, 0);
+          Some(joinValue(value));
         } else {
           None;
         },
@@ -143,8 +148,7 @@ let make = str => {
 
 let makeWith = (str, ~base: string) => {
   let baseUri = Uri.of_string(base);
-  let absolute = Uri.with_uri(~path=Some(str), baseUri);
-  Uri.resolve(str, baseUri, absolute);
+  Uri.resolve("", baseUri, Uri.of_string(str));
 };
 
 let host = url => {
@@ -200,9 +204,11 @@ let port = url => {
   | None => None
   };
 };
-/* TODO: Return result? or optional Maybe int_of_string fails */
 let setPort = (t, string) => {
-  Uri.with_port(t, Some(int_of_string(string)));
+  switch (int_of_string_opt(string)) {
+  | Some(port) => Uri.with_port(t, Some(port))
+  | None => t
+  };
 };
 let protocol = url => {
   switch (Uri.scheme(url)) {

--- a/packages/url/test/test_native.re
+++ b/packages/url/test/test_native.re
@@ -37,6 +37,22 @@ let url_tests = (
       assert_option_string(URL.host(url), Some("www.example.com"));
       assert_string(URL.pathname(url), "/cats");
     }),
+    case("makeWith and query", () => {
+      let url = URL.makeWith("page?x=1", ~base="https://a.dev/dir/");
+      assert_string(URL.toString(url), "https://a.dev/dir/page?x=1");
+    }),
+    case("makeWith and rooted path", () => {
+      let url = URL.makeWith("/rooted", ~base="https://a.dev/dir/page");
+      assert_string(URL.pathname(url), "/rooted");
+    }),
+    case("makeWith and absolute input", () => {
+      let url = URL.makeWith("https://other.dev/x", ~base="https://a.dev");
+      assert_option_string(URL.host(url), Some("other.dev"));
+    }),
+    case("makeWith and fragment", () => {
+      let url = URL.makeWith("#frag", ~base="https://a.dev/page");
+      assert_string(URL.toString(url), "https://a.dev/page#frag");
+    }),
     case("host", () => {
       let url = URL.makeExn("https://sancho.dev");
       assert_option_string(URL.host(url), Some("sancho.dev"));
@@ -84,6 +100,16 @@ let url_tests = (
       let url = URL.makeExn("https://sancho.dev");
       assert_option_string(URL.port(url), None);
       let url = URL.makeExn("https://sancho.dev:1234");
+      assert_option_string(URL.port(url), Some("1234"));
+    }),
+    case("setPort", () => {
+      let url = URL.makeExn("https://sancho.dev:1234");
+      let url = URL.setPort(url, "8080");
+      assert_option_string(URL.port(url), Some("8080"));
+    }),
+    case("setPort with invalid input leaves the URL unchanged", () => {
+      let url = URL.makeExn("https://sancho.dev:1234");
+      let url = URL.setPort(url, "abc");
       assert_option_string(URL.port(url), Some("1234"));
     }),
     case("hash", () => {
@@ -247,6 +273,23 @@ let url_search_params_tests =
         /* let noEquals = SearchParams.makeExn("foo&bar=baz");
            assert_option_string(SearchParams.get(noEquals, "foo"), Some("")); */
         /* assert_string(SearchParams.toString(noEquals), "foo=&bar=baz"); */
+      }),
+      case("get with comma-separated value", () => {
+        let url = URL.makeExn("https://a.dev?tags=x,y");
+        let params = URL.searchParams(url);
+        assert_option_string(SearchParams.get(params, "tags"), Some("x,y"));
+        assert_entries(SearchParams.entries(params), [|("tags", "x,y")|]);
+      }),
+      case("set on absent key appends", () => {
+        let search = SearchParams.makeExn("a=1");
+        let search = SearchParams.set(search, "b", "2");
+        assert_string(SearchParams.toString(search), "a=1&b=2");
+      }),
+      case("set on duplicate keys keeps first with new value", () => {
+        let search = SearchParams.makeExn("k=1&z=9");
+        let search = SearchParams.append(search, "k", "2");
+        let search = SearchParams.set(search, "k", "new");
+        assert_string(SearchParams.toString(search), "k=new&z=9");
       }),
       case("getAll", () => {
         let search = SearchParams.makeExn("topic=api");


### PR DESCRIPTION
Four WHATWG divergences in the native `URL` implementation (the browser side binds `window.URL`; universal code only works if both sides agree). Every expected value was checked against Node v22 as the WHATWG arbiter.

1. **`makeWith` misused `Uri.resolve`** — the relative URL was passed as the *scheme* argument, and the whole relative string (including `?query`/`#fragment`) was stuffed into the base's path. Now `Uri.resolve("", base, Uri.of_string(str))`: `makeWith("page?x=1", ~base="https://a.dev/dir/")` → `https://a.dev/dir/page?x=1`; absolute inputs win; `#frag` resolves against the base page.
2. **`SearchParams.joinValue` joined multi-values with `""`** — `a=1,2` round-tripped as `"12"` (silent data corruption). Now joins with `","`; `get` returns the joined value like the browser (first *pair* still wins for duplicate keys, per WHATWG).
3. **`SearchParams.set` dropped absent keys** (WHATWG appends) and overwrote every duplicate (WHATWG keeps first, deletes rest). Rewritten as a fold with both behaviors.
4. **`setPort` raised on non-numeric input** (`int_of_string`). Now total: invalid input leaves the URL unchanged, matching browser `url.port = "abc"`.

9 new test cases; existing URL tests pass unmodified.

Known pre-existing divergence, deliberately out of scope: `getAll` pins Uri's comma-splitting (`topic=api,webdev` → `[|"api"; "webdev"|]`) where browsers return one `"api,webdev"` — flagged for a follow-up rather than changed here.

`make build`, `make test`, `make format-check` all green.
