### PR TITLE
feat: make branch scope graftable, not reusable

### DIFF
--- a/demo/dream-router/test_dream_router.ml
+++ b/demo/dream-router/test_dream_router.ml
@@ -237,8 +237,8 @@ let registry_mismatch_returns_reload_required () =
   Alcotest.(check (option string)) "endpoint skipped" None !seen
 
 let patch_registry () : ((React.element, string) RouterServer.Plan.t, string) RouterServer.EndpointRegistry.t =
-  let root_branch = RouterServer.Branch.Scope.make ~id:"root" ~parameters:[] ~reusable:true in
-  let route_branch id = RouterServer.Branch.Scope.make ~id ~parameters:[] ~reusable:true in
+  let root_branch = RouterServer.Branch.Scope.make ~id:"root" ~parameters:[] ~graftable:true in
+  let route_branch id = RouterServer.Branch.Scope.make ~id ~parameters:[] ~graftable:true in
   let root_scope =
     RouterServer.Plan.Scope.make ~layout:(fun child -> React.array [| React.string (String.make 2000 'x'); child |]) ()
   in

--- a/documentation/router.mld
+++ b/documentation/router.mld
@@ -249,7 +249,7 @@ rendering begin. The scope's components receive [Data] ([~note] in the
 manifest above). [NotFound] and [Error] render the nearest boundary, and
 [Redirect(destination)] escapes the whole branch.
 
-A loader marks its scope and all descendants as non-reusable for navigation
+A loader marks its scope and all descendants as non-graftable for navigation
 patches. Keep loaders for fast validation, redirects, and route-level
 not-found decisions; stream slow data from async server components inside the
 route elements instead.

--- a/packages/router/generation/router_expansion.ml
+++ b/packages/router/generation/router_expansion.ml
@@ -679,16 +679,16 @@ let canonical_parameters ~loc parameters =
       B.pexp_tuple ~loc [ B.estring ~loc parameter.name; value ])
     parameters
 
-let branch_scope ~loc (scope : Router_declaration.scope) parameters ~reusable =
+let branch_scope ~loc (scope : Router_declaration.scope) parameters ~graftable =
   B.pexp_apply ~loc
     (B.evar ~loc "RouterServer.Branch.Scope.make")
     [
       (Labelled "id", B.estring ~loc scope.id);
       (Labelled "parameters", B.elist ~loc (canonical_parameters ~loc parameters));
-      (Labelled "reusable", B.ebool ~loc reusable);
+      (Labelled "graftable", B.ebool ~loc graftable);
     ]
 
-let scope_plan (scope : Router_declaration.scope) parameters search loaders ~reusable =
+let scope_plan (scope : Router_declaration.scope) parameters search loaders ~graftable =
   let loc = scope.loc in
   let callback attachment = apply_native_inputs ~loc attachment parameters search loaders in
   let component attachment = apply_native_component_inputs ~loc attachment parameters search loaders in
@@ -696,7 +696,7 @@ let scope_plan (scope : Router_declaration.scope) parameters search loaders ~reu
     (match (scope.attachments.layout, scope.attachments.loading) with
       | None, None -> []
       | layout, loading ->
-          let identity = branch_scope ~loc scope parameters ~reusable in
+          let identity = branch_scope ~loc scope parameters ~graftable in
           let instance_key =
             B.pexp_apply ~loc (B.evar ~loc "RouterServer.Branch.Scope.instanceKey") [ (Nolabel, identity) ]
           in
@@ -777,14 +777,16 @@ let loader_execution (route : Router_declaration.route) =
         in
         match scope.attachments.loader with
         | None ->
-            let reusable = (not loader_seen) && Option.is_some scope.attachments.layout in
-            let current = scope_plan scope parameters search loader_values ~reusable in
+            let graftable = Option.is_some scope.attachments.layout in
+            let current = scope_plan scope parameters search loader_values ~graftable in
             build rest parameters search loader_values (completed @ [ current ]) not_found error_boundary loader_seen
         | Some loader ->
             let run_call = apply_native_inputs ~loc:loader.loc loader.run parameters search loader_values in
             let run = B.pexp_fun ~loc:loader.loc Nolabel None (B.punit ~loc:loader.loc) run_call in
             let next_loaders = loader_values @ [ loader.result_label ] in
-            let current = scope_plan scope parameters search next_loaders ~reusable:false in
+            let current =
+              scope_plan scope parameters search next_loaders ~graftable:(Option.is_some scope.attachments.layout)
+            in
             let next_body =
               build rest parameters search next_loaders (completed @ [ current ]) not_found error_boundary true
             in
@@ -818,17 +820,16 @@ let active_route_candidates routes pattern =
 
 let projected_branch (route : Router_declaration.route) =
   let loc = route.loc in
-  let rec build scopes parameters loader_seen projected =
+  let rec build scopes parameters projected =
     match scopes with
     | [] -> B.elist ~loc projected
     | (scope : Router_declaration.scope) :: scopes ->
         let parameters = parameters @ scope.parameters in
-        let has_loader = Option.is_some scope.attachments.loader in
-        let reusable = (not loader_seen) && (not has_loader) && Option.is_some scope.attachments.layout in
-        let projected = projected @ [ branch_scope ~loc:scope.loc scope parameters ~reusable ] in
-        build scopes parameters (loader_seen || has_loader) projected
+        let graftable = Option.is_some scope.attachments.layout in
+        let projected = projected @ [ branch_scope ~loc:scope.loc scope parameters ~graftable ] in
+        build scopes parameters projected
   in
-  build route.scopes [] false []
+  build route.scopes [] []
 
 let recover_decode_failure ~loc ~branch ~scopes ~active_routes error_boundary =
   let plan = failure_plan ~loc scopes (B.evar ~loc "decodeError") None (Some error_boundary) in
@@ -857,8 +858,8 @@ let decode_endpoint ~routes (route : Router_declaration.route) prepared =
         let next_search = search @ scope.search in
         let next_pattern = RouterPattern.append pattern (parsed_path scope.path) in
         let has_loader = Option.is_some scope.attachments.loader in
-        let reusable = (not loader_seen) && (not has_loader) && Option.is_some scope.attachments.layout in
-        let next_branch = branch @ [ branch_scope ~loc scope next_parameters ~reusable ] in
+        let graftable = Option.is_some scope.attachments.layout in
+        let next_branch = branch @ [ branch_scope ~loc scope next_parameters ~graftable ] in
         let next_error_boundary =
           if loader_seen then error_boundary
           else
@@ -868,7 +869,7 @@ let decode_endpoint ~routes (route : Router_declaration.route) prepared =
         in
         let next_completed =
           if loader_seen || has_loader then completed
-          else completed @ [ scope_plan scope next_parameters next_search [] ~reusable ]
+          else completed @ [ scope_plan scope next_parameters next_search [] ~graftable ]
         in
         let success =
           build scopes next_pattern next_parameters next_search next_completed next_branch next_error_boundary
@@ -1082,7 +1083,9 @@ let fallback (declaration : Router_declaration.t) =
     Option.map (fun boundary -> boundary_callback ~loc:scope.loc boundary [] search []) scope.attachments.error
   in
   let completed =
-    match scope.attachments.loader with Some _ -> [] | None -> [ scope_plan scope [] search [] ~reusable:true ]
+    match scope.attachments.loader with
+    | Some _ -> []
+    | None -> [ scope_plan scope [] search [] ~graftable:(Option.is_some scope.attachments.layout) ]
   in
   let planned = failure_plan ~loc completed (B.evar ~loc "error") not_found error_boundary in
   let decoded =

--- a/packages/router/native/RouterServer.ml
+++ b/packages/router/native/RouterServer.ml
@@ -505,27 +505,31 @@ let status_of_error ~application = function
 
 module Branch = struct
   module Scope = struct
-    type t = { id : string; instance_key : string; reusable : bool }
+    type t = { id : string; instance_key : string; graftable : bool }
 
     let frame value = string_of_int (String.length value) ^ ":" ^ value
 
-    let make ~id ~parameters ~reusable =
+    let make ~id ~parameters ~graftable =
       let identity = parameters |> List.map (fun (name, value) -> frame name ^ frame value) |> String.concat "" in
-      { id; instance_key = frame id ^ identity; reusable }
+      { id; instance_key = frame id ^ identity; graftable }
 
     let id scope = scope.id
     let instanceKey scope = scope.instance_key
-    let reusable scope = scope.reusable
+    let graftable scope = scope.graftable
   end
 
   type t = Scope.t list
 
-  let rec sharedPrefix from target =
-    match (from, target) with
-    | left :: from, right :: target
-      when left.Scope.reusable && right.Scope.reusable && String.equal left.instance_key right.instance_key ->
-        1 + sharedPrefix from target
-    | _ -> 0
+  let insertionPoint ~from ~target =
+    let rec aux index bestInsertionPoint from target =
+      match (from, target) with
+      | left :: from, right :: target when String.equal left.Scope.instance_key right.Scope.instance_key ->
+          let insertionPoint = if Scope.graftable right then Some (index, right) else bestInsertionPoint in
+          aux (index + 1) insertionPoint from target
+      | _, [] -> None
+      | _ -> bestInsertionPoint
+    in
+    aux 0 None from target
 
   let layouts branch =
     List.map
@@ -824,12 +828,9 @@ module ServerEngine = struct
                     | Error _ -> None
                     | Ok prepared ->
                         let from_branch = Endpoint.branch prepared in
-                        let shared = Branch.sharedPrefix from_branch target_branch in
-                        if shared <= 0 || shared >= List.length target_branch then None
-                        else
-                          Option.map
-                            (fun scope -> (base_revision, shared, Branch.Scope.instanceKey scope))
-                            (List.nth_opt target_branch (shared - 1)))
+                        Option.map
+                          (fun (index, scope) -> (base_revision, index + 1, Branch.Scope.instanceKey scope))
+                          (Branch.insertionPoint ~from:from_branch ~target:target_branch))
                 | _ -> None))
       | _ -> None
     in

--- a/packages/router/native/RouterServer.mli
+++ b/packages/router/native/RouterServer.mli
@@ -2,7 +2,7 @@
 
     {!Path} and {!Search} first validate the untrusted URL. {!Registry} and
     {!Match} select a route, then {!Decode} gives the generated endpoint typed
-    inputs. The endpoint describes both its reusable layout {!Branch} and its
+    inputs. The endpoint describes both its graftable layout {!Branch} and its
     deferred loader {!Execution}. Finally, {!Plan} assembles the view, metadata,
     and headers while {!ServerEngine} decides whether the client needs a full
     response, a branch patch, a redirect, or a reload. *)
@@ -147,20 +147,20 @@ module Branch : sig
   module Scope : sig
     type t
 
-    val make : id:string -> parameters:(string * string) list -> reusable:bool -> t
+    val make : id:string -> parameters:(string * string) list -> graftable:bool -> t
     (** [parameters] are framed into [instanceKey], avoiding ambiguous keys when names or values have shared prefixes.
     *)
 
     val id : t -> string
     val instanceKey : t -> string
-    val reusable : t -> bool
+    val graftable : t -> bool
   end
 
   type t = Scope.t list
 
-  val sharedPrefix : t -> t -> int
-  (** Returns the number of leading layout instances that can survive a navigation. Comparison stops as soon as either
-      scope is not reusable. *)
+  val insertionPoint : from:t -> target:t -> (int * Scope.t) option
+  (** The deepest graftable scope shared by both branches, with its index. Returns [None] when there is no shared outlet
+      or the target has no suffix to insert. *)
 
   val layouts : t -> RouterRuntime.Navigation.layout list
 end

--- a/packages/router/native/test/test_router_server.ml
+++ b/packages/router/native/test/test_router_server.ml
@@ -806,16 +806,46 @@ let failure_plan_selects_not_found_boundary () =
   Alcotest.(check (option string)) "boundary" (Some "not-found") resolved.element;
   Alcotest.(check int) "status" 404 (Status.toInt resolved.status)
 
-let shared_layout_prefix_uses_canonical_identity () =
+let insertion_point_uses_canonical_identity () =
   let scope = RouterServer.Branch.Scope.make in
-  let root = scope ~id:"root" ~parameters:[] ~reusable:true in
-  let note = scope ~id:"group:note" ~parameters:[ ("id", "1") ] ~reusable:true in
-  let same = scope ~id:"group:note" ~parameters:[ ("id", "1") ] ~reusable:true in
-  let other = scope ~id:"group:note" ~parameters:[ ("id", "2") ] ~reusable:true in
-  let loaded = scope ~id:"group:note" ~parameters:[ ("id", "1") ] ~reusable:false in
-  Alcotest.(check int) "same" 2 (RouterServer.Branch.sharedPrefix [ root; note ] [ root; same ]);
-  Alcotest.(check int) "different params" 1 (RouterServer.Branch.sharedPrefix [ root; note ] [ root; other ]);
-  Alcotest.(check int) "loader scope" 1 (RouterServer.Branch.sharedPrefix [ root; note ] [ root; loaded ])
+  let root = scope ~id:"root" ~parameters:[] ~graftable:true in
+  let note = scope ~id:"group:note" ~parameters:[ ("id", "1") ] ~graftable:true in
+  let same = scope ~id:"group:note" ~parameters:[ ("id", "1") ] ~graftable:true in
+  let other = scope ~id:"group:note" ~parameters:[ ("id", "2") ] ~graftable:true in
+  let layoutless = scope ~id:"group:note" ~parameters:[ ("id", "1") ] ~graftable:false in
+  let leaf = scope ~id:"route:leaf" ~parameters:[] ~graftable:false in
+  let index from target = Option.map fst (RouterServer.Branch.insertionPoint ~from ~target) in
+  Alcotest.(check (option int)) "same" (Some 1) (index [ root; note ] [ root; same; leaf ]);
+  Alcotest.(check (option int)) "different params" (Some 0) (index [ root; note ] [ root; other; leaf ]);
+  Alcotest.(check (option int))
+    "layout-less scope is still shared" (Some 0)
+    (index [ root; note ] [ root; layoutless; leaf ]);
+  Alcotest.(check (option int)) "no target suffix" None (index [ root; note ] [ root; same ])
+
+let insertion_point_skips_layoutless_scopes () =
+  let scope = RouterServer.Branch.Scope.make in
+  let key = RouterServer.Branch.Scope.instanceKey in
+  let root = scope ~id:"root" ~parameters:[] ~graftable:true in
+  let workspace = scope ~id:"group:0" ~parameters:[ ("id", "1") ] ~graftable:false in
+  let shell = scope ~id:"group:0.0" ~parameters:[ ("id", "1") ] ~graftable:true in
+  let leaf = scope ~id:"route:Edit" ~parameters:[ ("id", "1") ] ~graftable:false in
+  let old_leaf = scope ~id:"route:View" ~parameters:[ ("id", "1") ] ~graftable:false in
+  let target = [ root; workspace; shell; leaf ] in
+  let point = RouterServer.Branch.insertionPoint ~from:[ root; workspace; shell; old_leaf ] ~target in
+  Alcotest.(check (option (pair int string)))
+    "deepest outlet"
+    (Some (2, key shell))
+    (Option.map (fun (index, scope) -> (index, key scope)) point);
+  Alcotest.(check (option (pair int string)))
+    "falls back to the root outlet"
+    (Some (0, key root))
+    (Option.map
+       (fun (index, scope) -> (index, key scope))
+       (RouterServer.Branch.insertionPoint ~from:[ root; scope ~id:"other" ~parameters:[] ~graftable:true ] ~target));
+  Alcotest.(check bool)
+    "nothing shared" true
+    (Option.is_none
+       (RouterServer.Branch.insertionPoint ~from:[ scope ~id:"other-root" ~parameters:[] ~graftable:true ] ~target))
 
 let suffix_plan_omits_shared_layouts () =
   let open RouterRuntime in
@@ -895,7 +925,8 @@ let () =
           test "server base path validation" server_base_path_validation;
           test "full plan composition" full_plan_composition;
           test "failure plan selects not-found boundary" failure_plan_selects_not_found_boundary;
-          test "shared layout prefix uses canonical identity" shared_layout_prefix_uses_canonical_identity;
+          test "insertion point uses canonical identity" insertion_point_uses_canonical_identity;
+          test "insertion point skips layout-less scopes" insertion_point_skips_layoutless_scopes;
           test "suffix plan omits shared layouts" suffix_plan_omits_shared_layouts;
         ] );
     ]

--- a/packages/router/test/cycle/native/test_cycle.re
+++ b/packages/router/test/cycle/native/test_cycle.re
@@ -811,7 +811,12 @@ let testPatchResponse = () => {
       "base-1",
       response.base_revision,
     );
-    Alcotest.check(Alcotest.string, "graft", "4:root", response.replace_from);
+    Alcotest.check(
+      Alcotest.string,
+      "graft",
+      "7:group:111:workspaceId1:7",
+      response.replace_from,
+    );
     Alcotest.check(
       Alcotest.string,
       "cache",


### PR DESCRIPTION
## Summary

Replace the reusable-prefix calculation with insertionPoint, which compares both branches and selects the deepest shared graftable scope. This allows patches to preserve nested layouts across layout-less or loader-bearing scopes instead of falling back to the root outlet.

So when ApplyPatch is set on the context, graftAt will be the best Outlet to set the patch and `String.equal(patch.graftAt, owner)` will work to apply the page.
```
  | ApplyPatch(patch) when String.equal(patch.graftAt, owner) => (
      patch.payload,
      patch.serial > saved.serial
        ? Some({
            serial: patch.serial,
            child: patch.payload,
          })
        : None,
    )
```

## How we can see that happening (Before):
```reason
  RouterOutlet.ApplyPatch({
    serial: 42,
    graftAt: "4:root",
    targetLayouts: [
      "4:root",
      "7:group:22:id1:1",
      "14:route:EditNote2:id1:1",
    ],
    payload: editNotePayload,
  });
```

https://github.com/user-attachments/assets/057e8e3e-028d-4215-a8ee-0e7e012da13f

## After:
```reason
  RouterOutlet.ApplyPatch({
    serial: 42,
    graftAt: "7:group:22:id1:1",
    targetLayouts: [
      "4:root",
      "7:group:22:id1:1",
      "14:route:EditNote2:id1:1",
    ],
    payload: editNotePayload,
  });
```

https://github.com/user-attachments/assets/774f0b16-2b39-43be-b68e-9bfd1ef52ef9

