### PR TITLE
Infer generated router interfaces

### DIFF
--- a/demo/router/generated/dune
+++ b/demo/router/generated/dune
@@ -1,5 +1,5 @@
 (rule
- (targets Router.ml Router.mli RouterRegistry.ml)
+ (targets Router.ml RouterRegistry.ml)
  (deps Routes.ml)
  (action
   (progn
@@ -11,16 +11,6 @@
       %{bin:server-reason-react.router-gen}
       --mode
       handles
-      --source
-      %{dep:Routes.ml})))
-   (with-stdout-to
-    Router.mli
-    (with-stdin-from
-     %{dep:Routes.ml}
-     (run
-      %{bin:server-reason-react.router-gen}
-      --mode
-      interface
       --source
       %{dep:Routes.ml})))
    (with-stdout-to

--- a/demo/router/js/dune
+++ b/demo/router/js/dune
@@ -29,7 +29,4 @@
  (files ../generated/Router.ml))
 
 (copy_files
- (files ../generated/Router.mli))
-
-(copy_files
  (files ../native/shared/*.re))

--- a/demo/router/native/dune
+++ b/demo/router/native/dune
@@ -26,7 +26,4 @@
  (files ../generated/Router.ml))
 
 (copy_files
- (files ../generated/Router.mli))
-
-(copy_files
  (files ../generated/RouterRegistry.ml))

--- a/packages/router/cram/typed-destination.t/run.t
+++ b/packages/router/cram/typed-destination.t/run.t
@@ -1,15 +1,6 @@
   $ export OCAMLRUNPARAM=
   $ server-reason-react.router-gen --mode handles --source input.ml < input.ml > Router.ml
-  $ server-reason-react.router-gen --mode interface --source input.ml < input.ml > Router.mli
-  $ grep -E '^type route|^val useRoute|useIsActive' Router.mli
-  type route =
-  val useRoute : unit -> route option
-  $ grep -E 'RouterRuntime\.(Navigation\.|Search\.)|RouterReact' Router.mli
-  [1]
-  $ grep -o 'enabled:bool' Router.mli | sort -u
-  enabled:bool
-  $ grep -o 'parts:string list' Router.mli | sort -u
-  parts:string list
+  $ server-reason-react.router-gen --mode interface --source input.ml < input.ml > Router_compat.mli
 
   $ server-reason-react.router-gen --mode handles --source catch-all-group.ml < catch-all-group.ml
   Fatal error: exception router: group path /assets/:parts<string...> cannot contain a catch-all segment
@@ -26,7 +17,7 @@
   $ server-reason-react.router-gen --mode registry --source catch-all-crossing.ml < catch-all-crossing.ml
   Fatal error: exception router: ambiguous route patterns /foo/:left<string...> and /:scope<string>/bar/:right<string...>
   [2]
-  $ grep -E 'old-notes|redirect:2' Router.mli
+  $ grep -E 'old-notes|redirect:2' Router_compat.mli
   [1]
   $ server-reason-react.router-gen --mode registry --source input.ml < input.ml | grep -Eo 'activeRoutes:\[\]|RouterServer.Execution.redirect|Router.Note.destination' | sort -u
   Router.Note.destination
@@ -37,7 +28,25 @@
   $ ocamlc -c React.ml
   $ ocamlc -c RouterReact.ml
   $ ocamlc -c NoteId.ml
-  $ ocamlc -c Router.mli
+  $ ocamlc -c Router_compat.mli
+  $ ocamlc -i Router.ml > Router.interface
+  $ grep -E '^type route|^val useRoute|useIsActive' Router.interface
+  type route =
+  val useRoute : unit -> route option
+  $ grep -E 'RouterRuntime\.(Navigation\.|Search\.)|RouterReact' Router.interface
+  [1]
+  $ grep -o 'enabled:bool' Router.interface | sort -u
+  enabled:bool
+  $ grep -o 'parts:string list' Router.interface | sort -u
+  parts:string list
+  $ grep -o '?className:string' Router.interface | sort -u
+  ?className:string
+  $ grep -o 'children:React.element' Router.interface | sort -u
+  children:React.element
+  $ grep -E 'old-notes|redirect:2' Router.interface
+  [1]
+  $ grep 'val pattern' Router.interface
+  [1]
   $ ocamlc -c Router.ml
   $ ocamlc -c unsafe_destination.ml
   $ ocamlc -c loader_redirect.ml

--- a/packages/router/generation/router_expansion.ml
+++ b/packages/router/generation/router_expansion.ml
@@ -248,16 +248,20 @@ let use_route_expression ~loc routes =
   in
   B.pexp_fun ~loc Nolabel None (B.punit ~loc) body
 
+let typed_function ~loc label name typ body =
+  let typ = match label with Optional _ -> option_type ~loc typ | Labelled _ | Nolabel -> typ in
+  B.pexp_fun ~loc label None (B.ppat_constraint ~loc (B.pvar ~loc name) typ) body
+
 let route_input_expression ~loc parameters search body =
   let body =
     List.fold_right
       (fun (search : Router_declaration.search) body ->
-        B.pexp_fun ~loc (search_argument_label search) None (B.pvar ~loc search.name) body)
+        typed_function ~loc (search_argument_label search) search.name (search_destination_type ~loc search) body)
       search body
   in
   List.fold_right
     (fun (parameter : Router_declaration.parameter) body ->
-      B.pexp_fun ~loc (Labelled parameter.name) None (B.pvar ~loc parameter.name) body)
+      typed_function ~loc (Labelled parameter.name) parameter.name parameter.typ body)
     parameters body
 
 let route_function_expression ~loc parameters search body =
@@ -428,10 +432,16 @@ let route_module ~base_path (route : Router_declaration.route) =
         (Labelled "search", search_values);
       ]
   in
-  let destination_expression = route_function_expression ~loc route.parameters route.search destination_body in
+  let destination_expression =
+    route_function_expression ~loc route.parameters route.search
+      (B.pexp_constraint ~loc destination_body (result_type ~loc "destination"))
+  in
   let destination_call = apply_route_inputs ~loc (B.evar ~loc "destination") route.parameters route.search in
   let href_body = B.pexp_apply ~loc (B.evar ~loc "RouterRuntime.href") [ (Nolabel, destination_call) ] in
-  let href_expression = route_function_expression ~loc route.parameters route.search href_body in
+  let href_expression =
+    route_function_expression ~loc route.parameters route.search
+      (B.pexp_constraint ~loc href_body (result_type ~loc "string"))
+  in
   let link_body =
     B.pexp_apply ~loc (B.evar ~loc "RouterReact.link")
       [
@@ -446,25 +456,50 @@ let route_module ~base_path (route : Router_declaration.route) =
         (Nolabel, unit_expression ~loc);
       ]
   in
-  let link_with_unit = B.pexp_fun ~loc Nolabel None (B.punit ~loc) link_body in
-  let link_with_children = B.pexp_fun ~loc (Labelled "children") None (B.pvar ~loc "children") link_with_unit in
+  let link_with_unit =
+    B.pexp_fun ~loc Nolabel None (B.punit ~loc) (B.pexp_constraint ~loc link_body (result_type ~loc "React.element"))
+  in
+  let link_with_children =
+    typed_function ~loc (Labelled "children") "children" (result_type ~loc "React.element") link_with_unit
+  in
   let link_with_revalidate =
-    B.pexp_fun ~loc (Optional "revalidate") None (B.pvar ~loc "revalidate") link_with_children
+    typed_function ~loc (Optional "revalidate") "revalidate" (bool_type ~loc) link_with_children
   in
-  let link_with_history = B.pexp_fun ~loc (Optional "history") None (B.pvar ~loc "history") link_with_revalidate in
+  let link_with_history =
+    typed_function ~loc (Optional "history") "history"
+      (result_type ~loc "Navigation.historyAction")
+      link_with_revalidate
+  in
   let link_with_aria_current =
-    B.pexp_fun ~loc (Optional "ariaCurrent") None (B.pvar ~loc "ariaCurrent") link_with_history
+    typed_function ~loc (Optional "ariaCurrent") "ariaCurrent" (result_type ~loc "string") link_with_history
   in
-  let link_with_download = B.pexp_fun ~loc (Optional "download") None (B.pvar ~loc "download") link_with_aria_current in
-  let link_with_target = B.pexp_fun ~loc (Optional "target") None (B.pvar ~loc "target") link_with_download in
-  let link_with_class_name = B.pexp_fun ~loc (Optional "className") None (B.pvar ~loc "className") link_with_target in
+  let link_with_download =
+    typed_function ~loc (Optional "download") "download" (result_type ~loc "string") link_with_aria_current
+  in
+  let link_with_target =
+    typed_function ~loc (Optional "target") "target" (result_type ~loc "string") link_with_download
+  in
+  let link_with_class_name =
+    typed_function ~loc (Optional "className") "className" (result_type ~loc "string") link_with_target
+  in
   let link_expression = route_input_expression ~loc route.parameters route.search link_with_class_name in
   let link_binding = B.value_binding ~loc ~pat:(B.pvar ~loc "make") ~expr:link_expression in
   let link_binding = { link_binding with pvb_attributes = [ react_component_attribute ~loc ] } in
+  let private_items =
+    B.pstr_open ~loc
+      {
+        popen_expr =
+          B.pmod_structure ~loc
+            [ B.pstr_value ~loc Nonrecursive [ B.value_binding ~loc ~pat:(B.pvar ~loc "pattern") ~expr:pattern ] ];
+        popen_override = Fresh;
+        popen_loc = loc;
+        popen_attributes = [];
+      }
+  in
   let module_expression =
     B.pmod_structure ~loc
       [
-        B.pstr_value ~loc Nonrecursive [ B.value_binding ~loc ~pat:(B.pvar ~loc "pattern") ~expr:pattern ];
+        private_items;
         B.pstr_value ~loc Nonrecursive
           [ B.value_binding ~loc ~pat:(B.pvar ~loc "destination") ~expr:destination_expression ];
         B.pstr_value ~loc Nonrecursive [ B.value_binding ~loc ~pat:(B.pvar ~loc "href") ~expr:href_expression ];
@@ -571,7 +606,10 @@ let search_contract_structure ~loc search =
           ]
           (B.pexp_tuple ~loc [ record; update_search ])
       in
-      B.pexp_fun ~loc Nolabel None (B.punit ~loc) body
+      B.pexp_constraint ~loc
+        (B.pexp_fun ~loc Nolabel None (B.punit ~loc) body)
+        (B.ptyp_arrow ~loc Nolabel (unit_type ~loc)
+           (B.ptyp_tuple ~loc [ result_type ~loc "search"; update_search_function_type ~loc search ]))
     in
     [
       B.pstr_type ~loc Recursive [ search_type_declaration ~loc search ];
@@ -586,14 +624,30 @@ let handles (declaration : Router_declaration.t) =
   B.pstr_type ~loc Recursive
     [ destination_declaration ~loc ~private_:Public ~manifest:(Some (result_type ~loc "RouterRuntime.destination")) ]
   :: B.pstr_value ~loc Nonrecursive
-       [ B.value_binding ~loc ~pat:(B.pvar ~loc "unsafeDestination") ~expr:(unsafe_destination_expression ~loc) ]
+       [
+         B.value_binding ~loc ~pat:(B.pvar ~loc "unsafeDestination")
+           ~expr:(B.pexp_constraint ~loc (unsafe_destination_expression ~loc) (unsafe_destination_type ~loc));
+       ]
   :: List.map (structure_alias ~loc) public_modules
   @ [ B.pstr_type ~loc Recursive [ route_type_declaration ~loc routes ] ]
   @ [
       B.pstr_value ~loc Nonrecursive
-        [ B.value_binding ~loc ~pat:(B.pvar ~loc "useNavigation") ~expr:(B.evar ~loc "RouterReact.useNavigation") ];
+        [
+          B.value_binding ~loc ~pat:(B.pvar ~loc "useNavigation")
+            ~expr:
+              (B.pexp_constraint ~loc
+                 (B.evar ~loc "RouterReact.useNavigation")
+                 (B.ptyp_arrow ~loc Nolabel (unit_type ~loc)
+                    (B.ptyp_tuple ~loc [ navigate_type ~loc; result_type ~loc "Navigation.status" ])));
+        ];
       B.pstr_value ~loc Nonrecursive
-        [ B.value_binding ~loc ~pat:(B.pvar ~loc "useUpdateHash") ~expr:(B.evar ~loc "RouterReact.useUpdateHash") ];
+        [
+          B.value_binding ~loc ~pat:(B.pvar ~loc "useUpdateHash")
+            ~expr:
+              (B.pexp_constraint ~loc
+                 (B.evar ~loc "RouterReact.useUpdateHash")
+                 (B.ptyp_arrow ~loc Nolabel (unit_type ~loc) (update_hash_type ~loc)));
+        ];
       B.pstr_value ~loc Nonrecursive
         [ B.value_binding ~loc ~pat:(B.pvar ~loc "useRoute") ~expr:(use_route_expression ~loc routes) ];
     ]

--- a/packages/router/test/cycle/js/dune
+++ b/packages/router/test/cycle/js/dune
@@ -42,9 +42,6 @@
  (files ../shared/Router.re))
 
 (copy_files
- (files ../shared/Router.rei))
-
-(copy_files
  (files ../shared/WorkspaceId.re))
 
 (copy_files

--- a/packages/router/test/cycle/native/dune
+++ b/packages/router/test/cycle/native/dune
@@ -54,9 +54,6 @@
  (files ../shared/Router.re))
 
 (copy_files
- (files ../shared/Router.rei))
-
-(copy_files
  (files ../shared/RouterRegistry.re))
 
 (copy_files

--- a/packages/router/test/cycle/shared/dune
+++ b/packages/router/test/cycle/shared/dune
@@ -1,5 +1,5 @@
 (rule
- (targets Router.re Router.rei RouterRegistry.re)
+ (targets Router.re RouterRegistry.re)
  (deps RouterDefinition.re)
  (action
   (progn
@@ -14,17 +14,6 @@
       --source
       %{dep:RouterDefinition.re})
      (run %{bin:refmt} --parse ml --print re)))
-   (with-stdout-to
-    Router.rei
-    (pipe-outputs
-     (run %{bin:refmt} --parse re --print ml %{dep:RouterDefinition.re})
-     (run
-      %{bin:server-reason-react.router-gen}
-      --mode
-      interface
-      --source
-      %{dep:RouterDefinition.re})
-     (run %{bin:refmt} --parse ml --print re --interface true)))
    (with-stdout-to
     RouterRegistry.re
     (pipe-outputs


### PR DESCRIPTION
## Summary

- stop generating and copying application `Router.mli` and `Router.rei` files
- preserve public type names with targeted annotations in generated `Router.ml`
- hide route patterns with an anonymous opened module
- keep the existing `--mode interface` generator command compatible

## Validation

- `make format-check`
- `make build`
- `make test`
