### PR TITLE
Update dune-release-action to v0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         run: opam install dune-release -y
 
       - name: Release
-        uses: davesnx/dune-release-action@v0.2.14
+        uses: davesnx/dune-release-action@v0.4.0
         if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest' && matrix.ocaml-compiler == '5.4.0'
         with:
           packages: 'server-reason-react'


### PR DESCRIPTION
Updates `dune-release-action` to [v0.4.0](https://github.com/davesnx/dune-release-action/blob/main/CHANGES.md).

Notable changes since older versions:

- New `pr-preamble-message` input to prepend custom text to the opam-repository PR description
- Fix `publish-message` input (previously passed as an unrecognized `--msg` flag, which failed the publish step when set)
- Action runtime upgraded to Node.js 24
- `dune-release-action/lint` sub-action for branch/PR linting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
